### PR TITLE
Split the response handling out of test server

### DIFF
--- a/webtau-feature-testing/src/main/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauEndToEndTestRunner.groovy
+++ b/webtau-feature-testing/src/main/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauEndToEndTestRunner.groovy
@@ -17,6 +17,7 @@
 
 package org.testingisdocumenting.webtau.featuretesting
 
+import org.eclipse.jetty.server.Handler
 import org.testingisdocumenting.webtau.cfg.WebTauConfig
 import org.testingisdocumenting.webtau.cli.WebTauCliApp
 import org.testingisdocumenting.webtau.documentation.DocumentationArtifactsLocation
@@ -32,8 +33,8 @@ class WebTauEndToEndTestRunner  {
 
     TestServer testServer
 
-    WebTauEndToEndTestRunner() {
-        testServer = new TestServer()
+    WebTauEndToEndTestRunner(Handler handler) {
+        this.testServer = new TestServer(handler)
     }
 
     void startTestServer() {

--- a/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauBrowserFeaturesTest.groovy
+++ b/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauBrowserFeaturesTest.groovy
@@ -18,7 +18,7 @@
 package org.testingisdocumenting.webtau.featuretesting
 
 import org.testingisdocumenting.webtau.cfg.GroovyConfigBasedBrowserPageNavigationHandler
-import org.testingisdocumenting.webtau.http.testserver.TestServer
+import org.testingisdocumenting.webtau.http.testserver.FixedResponsesHandler
 import org.testingisdocumenting.webtau.utils.ResourceUtils
 import org.junit.AfterClass
 import org.junit.Before
@@ -30,27 +30,27 @@ import static org.testingisdocumenting.webtau.featuretesting.FeaturesDocArtifact
 class WebTauBrowserFeaturesTest {
     private static WebTauEndToEndTestRunner testRunner
 
-    static void registerEndPoints(TestServer testServer) {
-        testServer.registerGet("/search", htmlResponse('search.html'))
-        testServer.registerGet("/forms", htmlResponse('forms.html'))
-        testServer.registerGet("/special-forms", htmlResponse('special-forms.html'))
-        testServer.registerGet("/calculation", htmlResponse('calculation.html'))
-        testServer.registerGet("/finders-and-filters", htmlResponse('finders-and-filters.html'))
-        testServer.registerGet("/element-actions", htmlResponse('element-actions.html'))
-        testServer.registerGet("/cookies", htmlResponse('cookies.html'))
-        testServer.registerGet("/matchers", htmlResponse('matchers.html'))
-        testServer.registerGet("/local-storage", htmlResponse('local-storage.html'))
-        testServer.registerGet("/logged-in-user", htmlResponse('logged-in-user.html'))
-        testServer.registerGet("/flicking-element", htmlResponse('flicking-element.html'))
-        testServer.registerGet("/resource-creation", htmlResponse('resource-creation.html'))
+    static void registerEndPoints(FixedResponsesHandler handler) {
+        handler.registerGet("/search", htmlResponse('search.html'))
+        handler.registerGet("/forms", htmlResponse('forms.html'))
+        handler.registerGet("/special-forms", htmlResponse('special-forms.html'))
+        handler.registerGet("/calculation", htmlResponse('calculation.html'))
+        handler.registerGet("/finders-and-filters", htmlResponse('finders-and-filters.html'))
+        handler.registerGet("/element-actions", htmlResponse('element-actions.html'))
+        handler.registerGet("/cookies", htmlResponse('cookies.html'))
+        handler.registerGet("/matchers", htmlResponse('matchers.html'))
+        handler.registerGet("/local-storage", htmlResponse('local-storage.html'))
+        handler.registerGet("/logged-in-user", htmlResponse('logged-in-user.html'))
+        handler.registerGet("/flicking-element", htmlResponse('flicking-element.html'))
+        handler.registerGet("/resource-creation", htmlResponse('resource-creation.html'))
     }
 
     @BeforeClass
     static void init() {
-        testRunner = new WebTauEndToEndTestRunner()
+        FixedResponsesHandler handler = new FixedResponsesHandler()
+        testRunner = new WebTauEndToEndTestRunner(handler)
 
-        def testServer = testRunner.testServer
-        registerEndPoints(testServer)
+        registerEndPoints(handler)
 
         testRunner.startTestServer()
     }

--- a/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTest.groovy
+++ b/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTest.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2020 webtau maintainers
  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTest.groovy
+++ b/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTest.groovy
@@ -20,6 +20,7 @@ package org.testingisdocumenting.webtau.featuretesting
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
+import org.testingisdocumenting.webtau.http.testserver.FixedResponsesHandler
 
 import static org.testingisdocumenting.webtau.WebTauDsl.http
 import static org.testingisdocumenting.webtau.featuretesting.FeaturesDocArtifactsExtractor.extractCodeSnippets
@@ -30,10 +31,10 @@ class WebTauRestFeaturesTest {
 
     @BeforeClass
     static void init() {
-        testRunner = new WebTauEndToEndTestRunner()
+        FixedResponsesHandler handler = new FixedResponsesHandler()
+        testRunner = new WebTauEndToEndTestRunner(handler)
 
-        def testServer = testRunner.testServer
-        WebTauRestFeaturesTestData.registerEndPoints(testServer)
+        WebTauRestFeaturesTestData.registerEndPoints(testRunner.testServer, handler)
 
         testRunner.startTestServer()
     }

--- a/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTestData.groovy
+++ b/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTestData.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2020 webtau maintainers
  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTestData.groovy
+++ b/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauRestFeaturesTestData.groovy
@@ -16,6 +16,7 @@
 
 package org.testingisdocumenting.webtau.featuretesting
 
+import org.testingisdocumenting.webtau.http.testserver.FixedResponsesHandler
 import org.testingisdocumenting.webtau.http.testserver.TestServer
 import org.testingisdocumenting.webtau.http.testserver.TestServerJsonResponse
 import org.testingisdocumenting.webtau.http.testserver.TestServerRedirectResponse
@@ -23,14 +24,14 @@ import org.testingisdocumenting.webtau.http.testserver.TestServerResponse
 import org.testingisdocumenting.webtau.utils.JsonUtils
 
 class WebTauRestFeaturesTestData {
-    static void registerEndPoints(TestServer testServer) {
+    static void registerEndPoints(TestServer testServer, FixedResponsesHandler handler) {
         def temperature = [temperature: 88]
-        testServer.registerGet("/weather", json(temperature))
-        testServer.registerGet("/redirect", new TestServerRedirectResponse(HttpURLConnection.HTTP_MOVED_TEMP,
+        handler.registerGet("/weather", json(temperature))
+        handler.registerGet("/redirect", new TestServerRedirectResponse(HttpURLConnection.HTTP_MOVED_TEMP,
                 testServer, "/weather"))
-        testServer.registerGet("/city/London", json([time: "2018-11-27 13:05:00", weather: temperature]))
-        testServer.registerPost("/employee", json([id: 'id-generated-2'], 201))
-        testServer.registerGet("/employee/id-generated-2", json([firstName: 'FN', lastName: 'LN']))
+        handler.registerGet("/city/London", json([time: "2018-11-27 13:05:00", weather: temperature]))
+        handler.registerPost("/employee", json([id: 'id-generated-2'], 201))
+        handler.registerGet("/employee/id-generated-2", json([firstName: 'FN', lastName: 'LN']))
 
     }
 

--- a/webtau-http/src/test/java/org/testingisdocumenting/webtau/http/HttpTestDataServer.java
+++ b/webtau-http/src/test/java/org/testingisdocumenting/webtau/http/HttpTestDataServer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2020 webtau maintainers
  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/webtau-http/src/test/java/org/testingisdocumenting/webtau/http/HttpTestDataServer.java
+++ b/webtau-http/src/test/java/org/testingisdocumenting/webtau/http/HttpTestDataServer.java
@@ -26,66 +26,65 @@ import java.util.Collections;
 import java.util.Map;
 
 public class HttpTestDataServer {
-    private final TestServer testServer;
+    private final FixedResponsesHandler handler = new FixedResponsesHandler();
+    private final TestServer testServer = new TestServer(handler);
 
     public HttpTestDataServer() {
-        testServer = new TestServer();
-
         TestServerJsonResponse objectTestResponse = jsonResponse("objectTestResponse.json");
 
-        testServer.registerGet("/end-point", objectTestResponse);
-        testServer.registerGet("/end-point?queryParam1=queryParamValue1", objectTestResponse);
+        handler.registerGet("/end-point", objectTestResponse);
+        handler.registerGet("/end-point?queryParam1=queryParamValue1", objectTestResponse);
 
-        testServer.registerPost("/end-point", jsonResponse("objectTestResponse.json", 201,
+        handler.registerPost("/end-point", jsonResponse("objectTestResponse.json", 201,
                 CollectionUtils.aMapOf(
                         "Content-Location", "/url/23",
                         "Location", "http://www.example.org/url/23")));
 
-        testServer.registerGet("/example", jsonResponse("matcherExampleResponse.json"));
+        handler.registerGet("/example", jsonResponse("matcherExampleResponse.json"));
 
-        testServer.registerPut("/end-point", objectTestResponse);
-        testServer.registerPatch("/end-point", objectTestResponse);
-        testServer.registerDelete("/end-point", objectTestResponse);
-        testServer.registerGet("/end-point-simple-object", jsonResponse("simpleObjectTestResponse.json"));
-        testServer.registerGet("/end-point-simple-list", jsonResponse("simpleListTestResponse.json"));
-        testServer.registerGet("/end-point-mixed", jsonResponse("mixedTestResponse.json"));
-        testServer.registerGet("/end-point-numbers", jsonResponse("numbersTestResponse.json"));
-        testServer.registerGet("/end-point-list", jsonResponse("listTestResponse.json"));
-        testServer.registerGet("/end-point-dates", jsonResponse("datesTestResponse.json"));
-        testServer.registerGet("/binary", new TestServerBinaryResponse(ResourceUtils.binaryContent("image.png")));
-        testServer.registerPost("/echo", new TestServerResponseEcho(201));
-        testServer.registerPut("/echo", new TestServerResponseEcho(200));
-        testServer.registerPatch("/echo", new TestServerResponseEcho(200));
-        testServer.registerPut("/full-echo", new TestServerRequestFullEcho(200));
-        testServer.registerPut("/full-echo?a=1&b=text", new TestServerRequestFullEcho(200));
-        testServer.registerPost("/full-echo", new TestServerRequestFullEcho(201));
-        testServer.registerPost("/full-echo?a=1&b=text", new TestServerRequestFullEcho(201));
-        testServer.registerPatch("/full-echo", new TestServerRequestFullEcho(200));
-        testServer.registerPatch("/full-echo?a=1&b=text", new TestServerRequestFullEcho(200));
-        testServer.registerDelete("/full-echo", new TestServerRequestFullEcho(200));
-        testServer.registerDelete("/full-echo?a=1&b=text", new TestServerRequestFullEcho(200));
-        testServer.registerGet("/echo-header", new TestServerRequestHeaderEcho(200));
-        testServer.registerGet("/echo-header?qp1=v1", new TestServerRequestHeaderEcho(200));
-        testServer.registerPatch("/echo-header", new TestServerRequestHeaderEcho(200));
-        testServer.registerPost("/echo-header", new TestServerRequestHeaderEcho(201));
-        testServer.registerPut("/echo-header", new TestServerRequestHeaderEcho(200));
-        testServer.registerPatch("/echo-header", new TestServerRequestHeaderEcho(200));
-        testServer.registerDelete("/echo-header", new TestServerRequestHeaderEcho(200));
-        testServer.registerPost("/echo-body-and-header", new TestServerRequestHeaderAndBodyEcho(201));
-        testServer.registerPost("/echo-multipart-content-part-one", new TestServerMultiPartContentEcho(201, 0));
-        testServer.registerPost("/echo-multipart-content-part-two", new TestServerMultiPartContentEcho(201, 1));
-        testServer.registerPost("/echo-multipart-meta", new TestServerMultiPartMetaEcho(201));
-        testServer.registerPost("/empty", new TestServerJsonResponse(null, 201));
-        testServer.registerPatch("/empty", new TestServerJsonResponse(null, 204));
-        testServer.registerPost("/file-upload", new TestServerFakeFileUpload());
-        testServer.registerDelete("/resource", new TestServerTextResponse("abc"));
-        testServer.registerGet("/params?a=1&b=text", new TestServerJsonResponse("{\"a\": 1, \"b\": \"text\"}"));
-        testServer.registerPost("/params?a=1&b=text", new TestServerJsonResponse("{\"a\": 1, \"b\": \"text\"}", 201));
-        testServer.registerGet("/params?message=hello+world+%21", new TestServerJsonResponse("{}", 200));
-        testServer.registerGet("/integer", new TestServerJsonResponse("123"));
-        testServer.registerPost("/json-derivative", new TestServerJsonDerivativeResponse());
+        handler.registerPut("/end-point", objectTestResponse);
+        handler.registerPatch("/end-point", objectTestResponse);
+        handler.registerDelete("/end-point", objectTestResponse);
+        handler.registerGet("/end-point-simple-object", jsonResponse("simpleObjectTestResponse.json"));
+        handler.registerGet("/end-point-simple-list", jsonResponse("simpleListTestResponse.json"));
+        handler.registerGet("/end-point-mixed", jsonResponse("mixedTestResponse.json"));
+        handler.registerGet("/end-point-numbers", jsonResponse("numbersTestResponse.json"));
+        handler.registerGet("/end-point-list", jsonResponse("listTestResponse.json"));
+        handler.registerGet("/end-point-dates", jsonResponse("datesTestResponse.json"));
+        handler.registerGet("/binary", new TestServerBinaryResponse(ResourceUtils.binaryContent("image.png")));
+        handler.registerPost("/echo", new TestServerResponseEcho(201));
+        handler.registerPut("/echo", new TestServerResponseEcho(200));
+        handler.registerPatch("/echo", new TestServerResponseEcho(200));
+        handler.registerPut("/full-echo", new TestServerRequestFullEcho(200));
+        handler.registerPut("/full-echo?a=1&b=text", new TestServerRequestFullEcho(200));
+        handler.registerPost("/full-echo", new TestServerRequestFullEcho(201));
+        handler.registerPost("/full-echo?a=1&b=text", new TestServerRequestFullEcho(201));
+        handler.registerPatch("/full-echo", new TestServerRequestFullEcho(200));
+        handler.registerPatch("/full-echo?a=1&b=text", new TestServerRequestFullEcho(200));
+        handler.registerDelete("/full-echo", new TestServerRequestFullEcho(200));
+        handler.registerDelete("/full-echo?a=1&b=text", new TestServerRequestFullEcho(200));
+        handler.registerGet("/echo-header", new TestServerRequestHeaderEcho(200));
+        handler.registerGet("/echo-header?qp1=v1", new TestServerRequestHeaderEcho(200));
+        handler.registerPatch("/echo-header", new TestServerRequestHeaderEcho(200));
+        handler.registerPost("/echo-header", new TestServerRequestHeaderEcho(201));
+        handler.registerPut("/echo-header", new TestServerRequestHeaderEcho(200));
+        handler.registerPatch("/echo-header", new TestServerRequestHeaderEcho(200));
+        handler.registerDelete("/echo-header", new TestServerRequestHeaderEcho(200));
+        handler.registerPost("/echo-body-and-header", new TestServerRequestHeaderAndBodyEcho(201));
+        handler.registerPost("/echo-multipart-content-part-one", new TestServerMultiPartContentEcho(201, 0));
+        handler.registerPost("/echo-multipart-content-part-two", new TestServerMultiPartContentEcho(201, 1));
+        handler.registerPost("/echo-multipart-meta", new TestServerMultiPartMetaEcho(201));
+        handler.registerPost("/empty", new TestServerJsonResponse(null, 201));
+        handler.registerPatch("/empty", new TestServerJsonResponse(null, 204));
+        handler.registerPost("/file-upload", new TestServerFakeFileUpload());
+        handler.registerDelete("/resource", new TestServerTextResponse("abc"));
+        handler.registerGet("/params?a=1&b=text", new TestServerJsonResponse("{\"a\": 1, \"b\": \"text\"}"));
+        handler.registerPost("/params?a=1&b=text", new TestServerJsonResponse("{\"a\": 1, \"b\": \"text\"}", 201));
+        handler.registerGet("/params?message=hello+world+%21", new TestServerJsonResponse("{}", 200));
+        handler.registerGet("/integer", new TestServerJsonResponse("123"));
+        handler.registerPost("/json-derivative", new TestServerJsonDerivativeResponse());
 
-        testServer.registerGet("/address", jsonResponse("addressResponse.json"));
+        handler.registerGet("/address", jsonResponse("addressResponse.json"));
         registerRedirects();
     }
 
@@ -94,21 +93,21 @@ public class HttpTestDataServer {
         registerRedirectOnAllMethods(HttpURLConnection.HTTP_MOVED_PERM, "/redirect2", "/redirect3");
         registerRedirectOnAllMethods(307, "/redirect3", "/redirect4");
 
-        testServer.registerGet("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/end-point"));
-        testServer.registerPost("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/echo"));
-        testServer.registerPut("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/echo"));
-        testServer.registerDelete("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/end-point"));
+        handler.registerGet("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/end-point"));
+        handler.registerPost("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/echo"));
+        handler.registerPut("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/echo"));
+        handler.registerDelete("/redirect4", new TestServerRedirectResponse(HttpURLConnection.HTTP_SEE_OTHER, testServer, "/end-point"));
 
-        testServer.registerGet("/recursive", new TestServerRedirectResponse(HttpURLConnection.HTTP_MOVED_TEMP, testServer, "/recursive"));
+        handler.registerGet("/recursive", new TestServerRedirectResponse(HttpURLConnection.HTTP_MOVED_TEMP, testServer, "/recursive"));
     }
 
     private void registerRedirectOnAllMethods(int statusCode, String fromPath, String toPath) {
         TestServerRedirectResponse response = new TestServerRedirectResponse(statusCode, testServer, toPath);
-        testServer.registerGet(fromPath, response);
-        testServer.registerPatch(fromPath, response);
-        testServer.registerPost(fromPath, response);
-        testServer.registerPut(fromPath, response);
-        testServer.registerDelete(fromPath, response);
+        handler.registerGet(fromPath, response);
+        handler.registerPatch(fromPath, response);
+        handler.registerPost(fromPath, response);
+        handler.registerPut(fromPath, response);
+        handler.registerDelete(fromPath, response);
     }
 
     public void start() {
@@ -124,23 +123,23 @@ public class HttpTestDataServer {
     }
 
     public void registerGet(String relativeUrl, TestServerResponse response) {
-        testServer.registerGet(relativeUrl, response);
+        handler.registerGet(relativeUrl, response);
     }
 
     public void registerPatch(String relativeUrl, TestServerResponse response) {
-        testServer.registerPatch(relativeUrl, response);
+        handler.registerPatch(relativeUrl, response);
     }
 
     public void registerPost(String relativeUrl, TestServerResponse response) {
-        testServer.registerPost(relativeUrl, response);
+        handler.registerPost(relativeUrl, response);
     }
 
     public void registerPut(String relativeUrl, TestServerResponse response) {
-        testServer.registerPut(relativeUrl, response);
+        handler.registerPut(relativeUrl, response);
     }
 
     public void registerDelete(String relativeUrl, TestServerResponse response) {
-        testServer.registerDelete(relativeUrl, response);
+        handler.registerDelete(relativeUrl, response);
     }
 
     private static TestServerJsonResponse jsonResponse(String resourceName) {

--- a/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/WebTauFeaturesJUnitTest.groovy
+++ b/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/WebTauFeaturesJUnitTest.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2020 webtau maintainers
  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/WebTauFeaturesJUnitTest.groovy
+++ b/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/WebTauFeaturesJUnitTest.groovy
@@ -18,13 +18,15 @@ package com.example.tests.junit4
 
 import com.example.tests.featuretest.JUnitFeatureTestRunner
 import org.testingisdocumenting.webtau.featuretesting.WebTauRestFeaturesTestData
+import org.testingisdocumenting.webtau.http.testserver.FixedResponsesHandler
 import org.testingisdocumenting.webtau.http.testserver.TestServer
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
 
 class WebTauFeaturesJUnitTest {
-    private static final TestServer testServer = new TestServer()
+    private static final FixedResponsesHandler handler = new FixedResponsesHandler()
+    private static final TestServer testServer = new TestServer(handler)
 
     private static final JUnitFeatureTestRunner testRunner = new JUnitFeatureTestRunner()
 
@@ -33,7 +35,7 @@ class WebTauFeaturesJUnitTest {
     @BeforeClass
     static void startServer() {
         testServer.startRandomPort()
-        WebTauRestFeaturesTestData.registerEndPoints(testServer)
+        WebTauRestFeaturesTestData.registerEndPoints(testServer, handler)
     }
 
     @AfterClass

--- a/webtau-pdf/src/test/groovy/org/testingisdocumenting/webtau/pdf/PdfHttpTest.groovy
+++ b/webtau-pdf/src/test/groovy/org/testingisdocumenting/webtau/pdf/PdfHttpTest.groovy
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2020 webtau maintainers
  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/webtau-pdf/src/test/groovy/org/testingisdocumenting/webtau/pdf/PdfHttpTest.groovy
+++ b/webtau-pdf/src/test/groovy/org/testingisdocumenting/webtau/pdf/PdfHttpTest.groovy
@@ -19,6 +19,7 @@ package org.testingisdocumenting.webtau.pdf
 import org.testingisdocumenting.webtau.http.HttpHeader
 import org.testingisdocumenting.webtau.http.config.HttpConfiguration
 import org.testingisdocumenting.webtau.http.config.HttpConfigurations
+import org.testingisdocumenting.webtau.http.testserver.FixedResponsesHandler
 import org.testingisdocumenting.webtau.http.testserver.TestServer
 import org.testingisdocumenting.webtau.http.testserver.TestServerBinaryResponse
 import org.testingisdocumenting.webtau.utils.ResourceUtils
@@ -34,13 +35,14 @@ import static org.testingisdocumenting.webtau.http.Http.http
 import static org.testingisdocumenting.webtau.pdf.Pdf.pdf
 
 class PdfHttpTest implements HttpConfiguration {
-    static TestServer testServer = new TestServer()
+    static FixedResponsesHandler handler = new FixedResponsesHandler()
+    static TestServer testServer = new TestServer(handler)
 
     @BeforeClass
     static void startServer() {
         testServer.startRandomPort()
 
-        testServer.registerGet("/report",
+        handler.registerGet("/report",
                 new TestServerBinaryResponse(ResourceUtils.binaryContent("report.pdf")))
     }
 

--- a/webtau-test-server/src/main/java/org/testingisdocumenting/webtau/http/testserver/FixedResponsesHandler.java
+++ b/webtau-test-server/src/main/java/org/testingisdocumenting/webtau/http/testserver/FixedResponsesHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 webtau maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.webtau.http.testserver;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FixedResponsesHandler extends AbstractHandler {
+    private final Map<String, TestServerResponse> getResponses = new HashMap<>();
+    private final Map<String, TestServerResponse> patchResponses = new HashMap<>();
+    private final Map<String, TestServerResponse> postResponses = new HashMap<>();
+    private final Map<String, TestServerResponse> putResponses = new HashMap<>();
+    private final Map<String, TestServerResponse> deleteResponses = new HashMap<>();
+
+    public void registerGet(String relativeUrl, TestServerResponse response) {
+        getResponses.put(relativeUrl, response);
+    }
+
+    public void registerPatch(String relativeUrl, TestServerResponse response) {
+        patchResponses.put(relativeUrl, response);
+    }
+
+    public void registerPost(String relativeUrl, TestServerResponse response) {
+        postResponses.put(relativeUrl, response);
+    }
+
+    public void registerPut(String relativeUrl, TestServerResponse response) {
+        putResponses.put(relativeUrl, response);
+    }
+
+    public void registerDelete(String relativeUrl, TestServerResponse response) {
+        deleteResponses.put(relativeUrl, response);
+    }
+
+    @Override
+    public void handle(String url, Request baseRequest, HttpServletRequest request,
+                       HttpServletResponse response) throws IOException, ServletException {
+
+        Map<String, TestServerResponse> responses = findResponses(request);
+
+        MultipartConfigElement multipartConfigElement = new MultipartConfigElement((String) null);
+        request.setAttribute(Request.MULTIPART_CONFIG_ELEMENT, multipartConfigElement);
+
+        TestServerResponse testServerResponse = responses.get(baseRequest.getOriginalURI());
+        if (testServerResponse == null) {
+            response.setStatus(404);
+        } else {
+            testServerResponse.responseHeader(request).forEach(response::addHeader);
+
+            byte[] responseBody = testServerResponse.responseBody(request);
+            response.setStatus(testServerResponse.responseStatusCode());
+            response.setContentType(testServerResponse.responseType(request));
+
+            if (responseBody != null) {
+                response.getOutputStream().write(responseBody);
+            }
+        }
+
+        baseRequest.setHandled(true);
+    }
+
+    private Map<String, TestServerResponse> findResponses(HttpServletRequest request) {
+        switch (request.getMethod()) {
+            case "GET":
+                return getResponses;
+            case "PATCH":
+                return patchResponses;
+            case "POST":
+                return postResponses;
+            case "PUT":
+                return putResponses;
+            case "DELETE":
+                return deleteResponses;
+            default:
+                return Collections.emptyMap();
+
+        }
+    }
+}

--- a/webtau-test-server/src/main/java/org/testingisdocumenting/webtau/http/testserver/TestServer.java
+++ b/webtau-test-server/src/main/java/org/testingisdocumenting/webtau/http/testserver/TestServer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2020 webtau maintainers
  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
For GraphQL integration testing, I would like a more flexible approach than <method, url> to response mapping.  I've therefore split out the actual request handling from `TestServer` so it can be customised where it makes sense.

I wasn't completely happy to have various test classes know about Jetty's `Handler` but I also wasn't super thrilled to introduce an abstraction which in all likelihood would look almost identical.  Happy to hear your thoughts on the matter.