### PR TITLE
Initial graphql dsl support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <module>webtau-dist</module>
         <module>webtau-cli-testing</module>
         <module>webtau-graphql</module>
+        <module>webtau-graphql-groovy</module>
     </modules>
 
     <properties>

--- a/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
@@ -28,36 +28,21 @@ mutation complete($id: ID!) {
 '''
 
 scenario("list all tasks") {
-    http.post("/graphql", [query: listAllQuery]) {
-        statusCode.should == 200
+    graphql.execute(listAllQuery) {
         errors.should == null
-        body.data.allTasks.id.should == ["a", "b", "c"]
+        allTasks.id.should == ["a", "b", "c"]
     }
 }
 
 scenario("complete a task") {
-    def completionRequest = [
-        query: completeMutation,
-        variables: [
-            id: "a"
-        ]
-    ]
-    http.post("/graphql", completionRequest) {
-        statusCode.should == 200
+    graphql.execute(completeMutation, [id: "a"]) {
         errors.should == null
-        body.data.complete.should == true
+        complete.should == true
     }
 
-    def getTaskRequest = [
-        query: taskByIdQuery,
-        variables: [
-            id: "a"
-        ]
-    ]
-    http.post("/graphql", getTaskRequest) {
-        statusCode.should == 200
+    graphql.execute(taskByIdQuery, [id: "a"]) {
         errors.should == null
-        body.data.taskById.id.should == "a"
-        body.data.taskById.completed.should == true
+        taskById.id.should == "a"
+        taskById.completed.should == true
     }
 }

--- a/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
@@ -47,6 +47,7 @@ scenario("list all tasks") {
     graphql.execute(listAllQuery) {
         errors.should == null
         allTasks.id.should == ["a", "b", "c"]
+        body.data.allTasks.id.should == ["a", "b", "c"]
     }
 }
 

--- a/webtau-feature-testing/pom.xml
+++ b/webtau-feature-testing/pom.xml
@@ -59,6 +59,12 @@
 
         <dependency>
             <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-graphql-groovy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
             <artifactId>webtau-utils</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/webtau-feature-testing/test-expectations/scenarios/graphql/queryAndMutation/run-details.json
+++ b/webtau-feature-testing/test-expectations/scenarios/graphql/queryAndMutation/run-details.json
@@ -3,7 +3,7 @@
     "scenario" : "list all tasks",
     "shortContainerId" : "queryAndMutation.groovy",
     "stepsSummary" : {
-      "numberOfSuccessful" : 4
+      "numberOfSuccessful" : 5
     }
   }, {
     "scenario" : "complete a task",

--- a/webtau-graphql-groovy/pom.xml
+++ b/webtau-graphql-groovy/pom.xml
@@ -29,5 +29,11 @@
             <artifactId>webtau-graphql</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-groovydoc</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webtau-graphql-groovy/pom.xml
+++ b/webtau-graphql-groovy/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>webtau-parent</artifactId>
+        <groupId>org.testingisdocumenting.webtau</groupId>
+        <version>1.26-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>webtau-graphql-groovy</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-core-groovy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-http-groovy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-graphql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/webtau-graphql-groovy/pom.xml
+++ b/webtau-graphql-groovy/pom.xml
@@ -65,5 +65,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-test-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webtau-graphql-groovy/pom.xml
+++ b/webtau-graphql-groovy/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 webtau maintainers
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/webtau-graphql-groovy/pom.xml
+++ b/webtau-graphql-groovy/pom.xml
@@ -51,5 +51,19 @@
             <artifactId>groovy-groovydoc</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-graphql</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webtau-graphql-groovy/src/main/groovy/org/testingisdocumenting/webtau/graphql/GraphQLExtensions.groovy
+++ b/webtau-graphql-groovy/src/main/groovy/org/testingisdocumenting/webtau/graphql/GraphQLExtensions.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 webtau maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.testingisdocumenting.webtau.graphql
 
 import org.testgisdocumenting.webtau.graphql.GraphQL

--- a/webtau-graphql-groovy/src/main/groovy/org/testingisdocumenting/webtau/graphql/GraphQLExtensions.groovy
+++ b/webtau-graphql-groovy/src/main/groovy/org/testingisdocumenting/webtau/graphql/GraphQLExtensions.groovy
@@ -1,0 +1,57 @@
+package org.testingisdocumenting.webtau.graphql
+
+import org.testgisdocumenting.webtau.graphql.GraphQL
+import org.testingisdocumenting.webtau.http.HttpHeader
+import org.testingisdocumenting.webtau.http.datanode.DataNode
+import org.testingisdocumenting.webtau.http.datanode.GroovyDataNode
+import org.testingisdocumenting.webtau.http.validation.HeaderDataNode
+import org.testingisdocumenting.webtau.http.validation.HttpResponseValidatorWithReturn
+
+class GraphQLExtensions {
+    static def execute(GraphQL graphQL, String query, Closure validation) {
+        return graphQL.execute(query, closureToHttpResponseValidator(validation))
+    }
+
+    static def execute(GraphQL graphQL, String query, Map<String, Object> variables, Closure validation) {
+        return graphQL.execute(query, variables, closureToHttpResponseValidator(validation))
+    }
+
+    static def execute(GraphQL graphQL, String query, Map<String, Object> variables, String operationName, HttpHeader header, Closure validation) {
+        return graphQL.execute(query, variables, operationName, header, closureToHttpResponseValidator(validation))
+    }
+
+    private static HttpResponseValidatorWithReturn closureToHttpResponseValidator(validation) {
+        return new HttpResponseValidatorWithReturn() {
+            @Override
+            def validate(final HeaderDataNode header, final DataNode body) {
+                def cloned = validation.clone() as Closure
+                cloned.delegate = new ValidatorDelegate(header, body)
+                cloned.resolveStrategy = Closure.OWNER_FIRST
+                return cloned.maximumNumberOfParameters == 2 ?
+                    cloned.call(header, new GroovyDataNode(body)) :
+                    cloned.call()
+            }
+        }
+    }
+
+    private static class ValidatorDelegate {
+        private HeaderDataNode header
+        private DataNode body
+
+        ValidatorDelegate(HeaderDataNode header, DataNode body) {
+            this.body = body
+            this.header = header
+        }
+
+        def getProperty(String name) {
+            switch (name) {
+                case "header":
+                    return new GroovyDataNode(header)
+                case "errors":
+                    return new GroovyDataNode(body).get("errors")
+                default:
+                    return new GroovyDataNode(body).get("data").get(name)
+            }
+        }
+    }
+}

--- a/webtau-graphql-groovy/src/main/groovy/org/testingisdocumenting/webtau/graphql/GraphQLExtensions.groovy
+++ b/webtau-graphql-groovy/src/main/groovy/org/testingisdocumenting/webtau/graphql/GraphQLExtensions.groovy
@@ -63,6 +63,8 @@ class GraphQLExtensions {
             switch (name) {
                 case "header":
                     return new GroovyDataNode(header)
+                case "body":
+                    return new GroovyDataNode(body)
                 case "errors":
                     return new GroovyDataNode(body).get("errors")
                 default:

--- a/webtau-graphql-groovy/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/webtau-graphql-groovy/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,19 @@
+#
+# Copyright 2020 webtau maintainers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+moduleName=webtau-graphql-groovy
+moduleVersion=1.0
+extensionClasses=org.testingisdocumenting.webtau.graphql.GraphQLExtensions

--- a/webtau-graphql-groovy/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLGroovyTest.groovy
+++ b/webtau-graphql-groovy/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLGroovyTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 webtau maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.webtau.graphql
+
+import org.junit.Test
+
+import static org.testgisdocumenting.webtau.graphql.GraphQL.graphql
+
+class GraphQLGroovyTest extends GraphQLTestBase {
+    @Test
+    void "execute"() {
+        def query = '''
+query {
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+'''
+
+        def expectedIds = ["a", "b", "c"]
+
+        def ids = graphql.execute(query) {
+            errors.should == null
+            allTasks.id.should == expectedIds
+
+            return allTasks.id
+        }
+
+        ids.should == expectedIds
+    }
+
+    @Test
+    void "execute with variables"() {
+        String query = '''
+query taskById($id: ID!) {
+    taskById(id: $id) {
+        id
+        description
+        completed
+    }
+}
+'''
+
+        def id = "a";
+        def variables = [id: id]
+
+        graphql.execute(query, variables) {
+            errors.should == null
+            taskById.id.should == id
+
+        }
+    }
+}

--- a/webtau-graphql/pom.xml
+++ b/webtau-graphql/pom.xml
@@ -47,10 +47,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-test-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math</artifactId>

--- a/webtau-graphql/pom.xml
+++ b/webtau-graphql/pom.xml
@@ -80,6 +80,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/webtau-graphql/src/test/java/org/testingisdocumenting/webtau/graphql/GraphQLJavaTest.java
+++ b/webtau-graphql/src/test/java/org/testingisdocumenting/webtau/graphql/GraphQLJavaTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 webtau maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.webtau.graphql;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.testgisdocumenting.webtau.graphql.GraphQL.graphql;
+import static org.testingisdocumenting.webtau.Matchers.actual;
+import static org.testingisdocumenting.webtau.Matchers.equal;
+import static org.testingisdocumenting.webtau.utils.CollectionUtils.aMapOf;
+
+public class GraphQLJavaTest extends GraphQLTestBase {
+    @Test
+    public void execute() {
+        String query = "query {" +
+                "    allTasks(uncompletedOnly: false) {" +
+                "        id" +
+                "        description" +
+                "    }" +
+                "}";
+
+        List<String> expectedIds = Arrays.asList("a", "b", "c");
+
+        List<String> ids = graphql.execute(query, (header, body) -> {
+            body.get("errors").should(equal(null));
+            body.get("data.allTasks.id").should(equal(expectedIds));
+            return body.get("data.allTasks.id");
+        });
+
+        actual(ids).should(equal(expectedIds));
+    }
+
+    @Test
+    public void executeWithVariables() {
+        String query = "query taskById($id: ID!) {" +
+                "    taskById(id: $id) {" +
+                "        id" +
+                "        description" +
+                "        completed" +
+                "    }" +
+                "}";
+
+        String id = "a";
+        Map<String, Object> variables = aMapOf("id", id);
+        graphql.execute(query, variables, (header, body) -> {
+            body.get("errors").should(equal(null));
+            body.get("data.taskById.id").should(equal(id));
+
+            // We can remove this once we have overrides which take HttpResponseValidatorIgnoringReturn
+            return null;
+        });
+    }
+}

--- a/webtau-graphql/src/test/java/org/testingisdocumenting/webtau/graphql/GraphQLTestBase.java
+++ b/webtau-graphql/src/test/java/org/testingisdocumenting/webtau/graphql/GraphQLTestBase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 webtau maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.webtau.graphql;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.testingisdocumenting.webtau.http.HttpHeader;
+import org.testingisdocumenting.webtau.http.config.HttpConfiguration;
+import org.testingisdocumenting.webtau.http.config.HttpConfigurations;
+import org.testingisdocumenting.webtau.utils.UrlUtils;
+
+public class GraphQLTestBase implements HttpConfiguration {
+    private static final GraphQLTestDataServer testServer = new GraphQLTestDataServer();
+
+    @BeforeClass
+    public static void startServer() {
+        testServer.start();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        testServer.stop();
+    }
+
+    @Before
+    public void initCfg() {
+        HttpConfigurations.add(this);
+    }
+
+    @After
+    public void cleanCfg() {
+        HttpConfigurations.remove(this);
+    }
+
+    @Override
+    public String fullUrl(String url) {
+        if (UrlUtils.isFull(url)) {
+            return url;
+        }
+
+        return UrlUtils.concat(testServer.getUri(), url);
+    }
+
+    @Override
+    public HttpHeader fullHeader(String fullUrl, String passedUrl, HttpHeader given) {
+        return given;
+    }
+}

--- a/webtau-graphql/src/test/java/org/testingisdocumenting/webtau/graphql/GraphQLTestDataServer.java
+++ b/webtau-graphql/src/test/java/org/testingisdocumenting/webtau/graphql/GraphQLTestDataServer.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 webtau maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.webtau.graphql;
+
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.schema.idl.TypeRuntimeWiring;
+import org.testingisdocumenting.webtau.http.testserver.GraphQLResponseHandler;
+import org.testingisdocumenting.webtau.http.testserver.TestServer;
+import org.testingisdocumenting.webtau.utils.ResourceUtils;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GraphQLTestDataServer {
+    private final TestServer testServer;
+
+    public GraphQLTestDataServer() {
+        String sdl = ResourceUtils.textContent("test-schema.graphql");
+        TypeDefinitionRegistry typeDefinitionRegistry = new SchemaParser().parse(sdl);
+
+        RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+        setupTestData(runtimeWiringBuilder);
+        RuntimeWiring runtimeWiring = runtimeWiringBuilder.build();
+
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+        GraphQLSchema schema = schemaGenerator.makeExecutableSchema(typeDefinitionRegistry, runtimeWiring);
+
+        GraphQLResponseHandler handler = new GraphQLResponseHandler(schema);
+        this.testServer = new TestServer(handler);
+    }
+
+    private static void setupTestData(RuntimeWiring.Builder builder) {
+        tasks.add(new Task("a", "first task", false));
+        tasks.add(new Task("b", "second task", false));
+        tasks.add(new Task("c", "already done", true));
+
+        TypeRuntimeWiring.Builder queries = TypeRuntimeWiring.newTypeWiring("Query");
+        queries.dataFetcher("allTasks", e -> allTasks(e.getArgument("uncompletedOnly")));
+        queries.dataFetcher("taskById",  e -> taskById(e.getArgument("id")));
+
+        TypeRuntimeWiring.Builder mutations = TypeRuntimeWiring.newTypeWiring("Mutation");
+        mutations.dataFetcher("complete", e -> setCompleted(e.getArgument("id"), true));
+        mutations.dataFetcher("uncomplete", e -> setCompleted(e.getArgument("id"), false));
+
+        builder.type(queries).type(mutations);
+    }
+
+    private static Boolean setCompleted(String id, Boolean completed) {
+        Task task = taskById(id);
+        if (task == null) {
+            return false;
+        } else {
+            task.completed = completed;
+            return true;
+        }
+    }
+
+    private static Task taskById(String id) {
+        return tasks.stream().filter(task -> task.id.equals(id)).findFirst().orElse(null);
+    }
+
+    private static List<Task> allTasks(boolean uncompletedOnly) {
+        return tasks.stream().filter(task -> !uncompletedOnly || !task.completed).collect(Collectors.toList());
+    }
+
+    private static List<Task> tasks = new ArrayList<>();
+
+    private static class Task {
+        private final String id;
+        private final String description;
+        private boolean completed;
+
+        Task(String id, String description, boolean completed) {
+            this.id = id;
+            this.description = description;
+            this.completed = completed;
+        }
+    }
+
+    public void start() {
+        testServer.startRandomPort();
+    }
+
+    public void stop() {
+        testServer.stop();
+    }
+
+    public URI getUri() {
+        return testServer.getUri();
+    }
+}

--- a/webtau-utils/src/main/java/org/testingisdocumenting/webtau/utils/CollectionUtils.java
+++ b/webtau-utils/src/main/java/org/testingisdocumenting/webtau/utils/CollectionUtils.java
@@ -76,6 +76,14 @@ public class CollectionUtils {
         }
     }
 
+    public static <K, V> boolean nullOrEmpty(Map<K, V> map) {
+        return map == null || map.isEmpty();
+    }
+
+    public static <K, V> boolean notNullOrEmpty(Map<K, V> map) {
+        return !nullOrEmpty(map);
+    }
+
     private static List<Boolean> toList(boolean[] booleans) {
         List<Boolean> list = new ArrayList<>(booleans.length);
         for (boolean bool : booleans) {

--- a/webtau-utils/src/main/java/org/testingisdocumenting/webtau/utils/JsonUtils.java
+++ b/webtau-utils/src/main/java/org/testingisdocumenting/webtau/utils/JsonUtils.java
@@ -52,7 +52,7 @@ public class JsonUtils {
         try {
             return mapper.writeValueAsString(json);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException();
+            throw new RuntimeException(e);
         }
     }
 

--- a/webtau/pom.xml
+++ b/webtau/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+  ~ Copyright 2020 webtau maintainers
   ~ Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/webtau/pom.xml
+++ b/webtau/pom.xml
@@ -89,6 +89,12 @@
 
         <dependency>
             <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-graphql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
             <artifactId>webtau-report</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/webtau/src/main/java/org/testingisdocumenting/webtau/WebTauDsl.java
+++ b/webtau/src/main/java/org/testingisdocumenting/webtau/WebTauDsl.java
@@ -17,6 +17,7 @@
 
 package org.testingisdocumenting.webtau;
 
+import org.testgisdocumenting.webtau.graphql.GraphQL;
 import org.testingisdocumenting.webtau.browser.Browser;
 import org.testingisdocumenting.webtau.browser.expectation.DisabledValueMatcher;
 import org.testingisdocumenting.webtau.browser.expectation.EnabledValueMatcher;
@@ -55,6 +56,7 @@ public class WebTauDsl extends WebTauCore {
     public static final Browser browser = Browser.browser;
     public static final Cli cli = Cli.cli;
     public static final DatabaseFacade db = DatabaseFacade.db;
+    public static final GraphQL graphql = GraphQL.graphql;
 
     public static WebTauConfig getCfg() {
         return WebTauConfig.getCfg();


### PR DESCRIPTION
I know I haven't added any tests, I will do that before I merge this PR.  However, I wanted to open it now to start a discussion about the DSL so comments very welcome 😁 

Some questions, comments, food for thought, etc. below.  Once we have some sort of consensus I can break these up into issues.

### Handling of `errors`

I'm in two minds about how to handle the `errors`.  Initially I was going to have default assertions if the user does not provide any (like status code for example).

However, that may be annoying because there may be cases where you just don't care whether there are errors if all else is good so you'd want to disable the default handling.  I'm not sure that's a common case though so perhaps the default handling makes sense.

### Query construction helpers

I think it would make sense to offer a better way to provide the query rather than as a string.  Perhaps we can construct it from a map or some other custom DSL support.

### CLI rendering of requests and responses

I'd like to override the rendering of queries and potentially responses.  Right now it'll print the json request as follows:

```
> executing HTTP POST http://127.0.0.1:52641/graphql
request (application/json):
{
  "query": "
query {
    allTasks(uncompletedOnly: false) {
        id
        description
    }
}
"
}
```

In this example it's just about ok but that's only because I formatted the input string.  I think we should override that but it'll require some changes to http handling to allow overriding the rendering.

Response rendering is less of an issue as responses are basically pure json but may make sense to have custom rendering for data and errors rather than the raw json.

### CLI rendering of assertions

Validations show up as follows:
```
  . body.data.allTasks.id equals [a, b, c]
      matches:
      
      body.data.allTasks.id[0]:   actual: "a" <java.lang.String>
                                expected: "a" <java.lang.String>
      body.data.allTasks.id[1]:   actual: "b" <java.lang.String>
                                expected: "b" <java.lang.String>
      body.data.allTasks.id[2]:   actual: "c" <java.lang.String>
                                expected: "c" <java.lang.String> (7ms)

```

My test makes no mention of `body` or `data` so this *could* be a little confusing.  That said, I think it's the same for pure HTTP where `foo.should == 1` shows up as `body.foo` so I'm ok with this.

### Implicit status code check

~The implicit status code check is printed to the screen which is not the case for the default HTTP status code checks.  We may want a different mechanism for performing this check.~ Turns out this is the same behaviour as with pure HTTP so will leave it as is.

### Missing features

1. much overriding for various combinations of query, variables, op name, headers, etc., sigh
1. some unit tests 😁 
1. some configurability though we may wish to wait until people ask for these things:
    1. url - in theory it's possible someone may serve at root for example, rather than `graphql`.  It's debatable whether we should do this at all or just force users to stick the `graphql` path in the base url config.
    1. success status code - in case people deviate from best practices
    1. invocation method - there are many ways to invoke a graphql service according to best practices: POST bodies like I've used, GET and query params and POST with `application/graphql` content type.  We probably should allow any of these.

Fixes #585 