### PR TITLE
core: clear added generators at the end of tests run

### DIFF
--- a/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauGraphQLFeaturesTest.groovy
+++ b/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauGraphQLFeaturesTest.groovy
@@ -44,8 +44,8 @@ class WebTauGraphQLFeaturesTest {
         runCli("queryAndMutation.groovy", "webtau.cfg", "--url=${testRunner.testServer.uri}")
     }
 
-    private static void runCli(String restTestName, String configFileName, String... additionalArgs) {
-        testRunner.runCli("scenarios/graphql/$restTestName",
+    private static void runCli(String graphQLTestName, String configFileName, String... additionalArgs) {
+        testRunner.runCli("scenarios/graphql/$graphQLTestName",
             "scenarios/graphql/$configFileName", additionalArgs)
     }
 }

--- a/webtau-groovy/src/main/groovy/org/testingisdocumenting/webtau/cli/WebTauCliApp.groovy
+++ b/webtau-groovy/src/main/groovy/org/testingisdocumenting/webtau/cli/WebTauCliApp.groovy
@@ -132,7 +132,7 @@ class WebTauCliApp implements TestListener, ReportGenerator {
 
             code()
         } finally {
-            removeListeners()
+            removeListenersAndHandlers()
 
             Pdf.closeAll()
 
@@ -146,7 +146,7 @@ class WebTauCliApp implements TestListener, ReportGenerator {
         consoleOutput = createConsoleOutput()
         stepReporter = createStepReporter()
 
-        registerListeners()
+        registerListenersAndHandlers()
 
         DocumentationArtifactsLocation.setRoot(cfg.getDocArtifactsPath())
 
@@ -157,19 +157,19 @@ class WebTauCliApp implements TestListener, ReportGenerator {
         WebTauGroovyDsl.initWithTestRunner(runner)
     }
 
-    private void registerListeners() {
+    private void registerListenersAndHandlers() {
+        StepReporters.add(stepReporter)
         ConsoleOutputs.add(consoleOutput)
         TestListeners.add(consoleTestReporter)
         TestListeners.add(this)
-        StepReporters.add(stepReporter)
         ReportGenerators.add(this)
     }
 
-    private void removeListeners() {
-        ConsoleOutputs.remove(consoleOutput)
+    private void removeListenersAndHandlers() {
         StepReporters.remove(stepReporter)
+        ConsoleOutputs.remove(consoleOutput)
         TestListeners.clearAdded()
-        ReportGenerators.remove(this)
+        ReportGenerators.clearAdded()
     }
 
     private void runTests() {

--- a/webtau-report/src/main/java/org/testingisdocumenting/webtau/report/ReportGenerators.java
+++ b/webtau-report/src/main/java/org/testingisdocumenting/webtau/report/ReportGenerators.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2020 webtau maintainers
  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,20 +20,27 @@ package org.testingisdocumenting.webtau.report;
 import org.testingisdocumenting.webtau.reporter.WebTauReport;
 import org.testingisdocumenting.webtau.utils.ServiceLoaderUtils;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class ReportGenerators {
-    private static final List<ReportGenerator> generators = ServiceLoaderUtils.load(ReportGenerator.class);
+    private static final List<ReportGenerator> discoveredGenerators = ServiceLoaderUtils.load(ReportGenerator.class);
+    private static final List<ReportGenerator> addedGenerators = new ArrayList<>();
 
     public static void generate(WebTauReport report) {
-        generators.forEach(g -> g.generate(report));
+        Stream.concat(discoveredGenerators.stream(), addedGenerators.stream()).forEach(g -> g.generate(report));
     }
 
     public static void add(ReportGenerator reportGenerator) {
-        generators.add(reportGenerator);
+        addedGenerators.add(reportGenerator);
     }
 
     public static void remove(ReportGenerator reportGenerator) {
-        generators.remove(reportGenerator);
+        addedGenerators.remove(reportGenerator);
+    }
+
+    public static void clearAdded() {
+        addedGenerators.clear();
     }
 }


### PR DESCRIPTION
Report Generators added using config file or explicit `.add` method are removed now at the end of tests run. 