### PR TITLE
Fix GraphQL query parsing

### DIFF
--- a/webtau-feature-testing/examples/scenarios/graphql/Report.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/Report.groovy
@@ -37,16 +37,16 @@ class Report {
             [
                 name: 'uncomplete',
                 type: 'mutation'
-            ],
-            [
-                name: 'allTasks',
-                type: 'query'
             ]
         ] as Set
     }
 
     static void validateCoveredOps(Set coveredOps) {
         coveredOps.should == [
+            [
+                name: 'allTasks',
+                type: 'query'
+            ],
             [
                 name: 'complete',
                 type: 'mutation'
@@ -59,7 +59,12 @@ class Report {
     }
 
     static void validateOperationStatistics(opStats) {
-        opStats.size().should == 2
+        opStats.size().should == 3
+
+        def allTasksQueryStats = opStats.find { it.name == 'allTasks' }
+        allTasksQueryStats.shouldNot == null
+        allTasksQueryStats.type.should == 'query'
+        allTasksQueryStats.statistics.size().shouldBe > 0
 
         def completeMutationStats = opStats.find { it.name == 'complete' }
         completeMutationStats.shouldNot == null
@@ -82,13 +87,13 @@ class Report {
                 ],
                 query: [
                     declaredOperations: 2,
-                    coveredOperations: 1,
-                    coverage: 0.5
+                    coveredOperations: 2,
+                    coverage: 1.0
                 ]
             ],
             totalDeclaredOperations: 4,
-            totalCoveredOperations: 2,
-            coverage: 0.5
+            totalCoveredOperations: 3,
+            coverage: 0.75
         ]
     }
 }

--- a/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
@@ -18,8 +18,16 @@ package scenarios.graphql
 
 import static org.testingisdocumenting.webtau.WebTauGroovyDsl.*
 
-def listAllQuery = '''
+/*def listAllQuery = '''
 query {
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+'''*/
+def listAllQuery = '''
+query allTasks {
     allTasks(uncompletedOnly: false) {
         id
         description

--- a/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
@@ -18,16 +18,8 @@ package scenarios.graphql
 
 import static org.testingisdocumenting.webtau.WebTauGroovyDsl.*
 
-/*def listAllQuery = '''
-query {
-    allTasks(uncompletedOnly: false) {
-        id
-        description
-    }
-}
-'''*/
 def listAllQuery = '''
-query allTasks {
+{
     allTasks(uncompletedOnly: false) {
         id
         description

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
@@ -19,7 +19,6 @@ package org.testingisdocumenting.webtau.graphql;
 import org.testingisdocumenting.webtau.http.validation.HttpValidationResult;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -36,8 +35,8 @@ public class GraphQLCoverage {
             return;
         }
 
-        Optional<GraphQLOperation> graphQLOperation = schema.findOperation(validationResult.getRequestBody());
-        graphQLOperation.ifPresent(operation -> coveredOperations.add(operation, validationResult.getId(), validationResult.getElapsedTime()));
+        Set<GraphQLOperation> graphQLOperations = schema.findOperations(validationResult.getRequestBody());
+        graphQLOperations.forEach(operation -> coveredOperations.add(operation, validationResult.getId(), validationResult.getElapsedTime()));
     }
 
     Stream<GraphQLOperation> nonCoveredOperations() {

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProvider.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProvider.java
@@ -33,23 +33,23 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class GraphQLReportDataProvider implements ReportDataProvider {
-    private final Supplier<GraphQLCoverage> coverage;
+    private final Supplier<GraphQLCoverage> coverageSupplier;
 
     public GraphQLReportDataProvider() {
         this(GraphQL::getCoverage);
     }
 
-    public GraphQLReportDataProvider(Supplier<GraphQLCoverage> coverage) {
-        this.coverage = coverage;
+    public GraphQLReportDataProvider(Supplier<GraphQLCoverage> coverageSupplier) {
+        this.coverageSupplier = coverageSupplier;
     }
 
     @Override
     public Stream<ReportCustomData> provide(WebTauTestList tests) {
-        List<? extends Map<String, ?>> nonCoveredOperations = coverage.get().nonCoveredOperations()
+        List<? extends Map<String, ?>> nonCoveredOperations = coverageSupplier.get().nonCoveredOperations()
                 .map(GraphQLOperation::toMap)
                 .collect(Collectors.toList());
 
-        List<? extends Map<String, ?>> coveredOperations = coverage.get().coveredOperations()
+        List<? extends Map<String, ?>> coveredOperations = coverageSupplier.get().coveredOperations()
                 .map(GraphQLOperation::toMap)
                 .collect(Collectors.toList());
 
@@ -65,7 +65,7 @@ public class GraphQLReportDataProvider implements ReportDataProvider {
     }
 
     private List<? extends Map<String, ?>> computeTiming() {
-        return coverage.get().actualCalls().map(GraphQLReportDataProvider::computeTiming).collect(Collectors.toList());
+        return coverageSupplier.get().actualCalls().map(GraphQLReportDataProvider::computeTiming).collect(Collectors.toList());
     }
 
     private static Map<String, ?> computeTiming(Map.Entry<GraphQLOperation, Set<GraphQLCoveredOperations.Call>> entry) {
@@ -91,8 +91,8 @@ public class GraphQLReportDataProvider implements ReportDataProvider {
 
     private Map<String, ?> computeCoverageSummary() {
         Map<String, Object> summary = new HashMap<>();
-        Map<GraphQLOperationType, List<GraphQLOperation>> declaredOpByType = coverage.get().declaredOperations().collect(Collectors.groupingBy(GraphQLOperation::getType));
-        Map<GraphQLOperationType, List<GraphQLOperation>> coveredOpsByType = coverage.get().coveredOperations().collect(Collectors.groupingBy(GraphQLOperation::getType));
+        Map<GraphQLOperationType, List<GraphQLOperation>> declaredOpByType = coverageSupplier.get().declaredOperations().collect(Collectors.groupingBy(GraphQLOperation::getType));
+        Map<GraphQLOperationType, List<GraphQLOperation>> coveredOpsByType = coverageSupplier.get().coveredOperations().collect(Collectors.groupingBy(GraphQLOperation::getType));
 
         Map<String, Object> summaryByType = new HashMap<>();
         declaredOpByType.forEach((type, ops) -> {

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchema.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchema.java
@@ -96,8 +96,8 @@ public class GraphQLSchema {
             return emptySet();
         }
 
+        List<OperationDefinition> operations = parsingResult.getDocument().getDefinitionsOfType(OperationDefinition.class);
         if (operationName != null) {
-            List<OperationDefinition> operations = parsingResult.getDocument().getDefinitionsOfType(OperationDefinition.class);
             List<OperationDefinition> matchingOperations = operations.stream().filter(operationDefinition -> operationName.equals(operationDefinition.getName())).collect(Collectors.toList());
             if (matchingOperations.size() != 1) {
                 // Either no matching operation or more than one, either way it's not valid GraphQL
@@ -107,7 +107,6 @@ public class GraphQLSchema {
             Optional<OperationDefinition> matchingOperation = matchingOperations.stream().findFirst();
             return matchingOperation.map(GraphQLSchema::extractOperations).orElseGet(Collections::emptySet);
         } else {
-            List<OperationDefinition> operations = parsingResult.getDocument().getDefinitionsOfType(OperationDefinition.class);
             if (operations.size() > 1) {
                 // This is not valid in GraphQL, if you have more than one operation, you need to specify a name
                 return emptySet();

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchema.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchema.java
@@ -19,6 +19,7 @@ package org.testingisdocumenting.webtau.graphql;
 import graphql.ExecutionInput;
 import graphql.ParseAndValidate;
 import graphql.ParseAndValidateResult;
+import graphql.language.Field;
 import graphql.language.OperationDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.idl.RuntimeWiring;
@@ -31,13 +32,17 @@ import org.testingisdocumenting.webtau.utils.JsonUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.Collections.emptySet;
 
 public class GraphQLSchema {
     private final boolean isSchemaDefined;
@@ -76,26 +81,48 @@ public class GraphQLSchema {
         return schemaDeclaredOperations.stream();
     }
 
-    public Optional<GraphQLOperation> findOperation(HttpRequestBody requestBody) {
+    public Set<GraphQLOperation> findOperations(HttpRequestBody requestBody) {
         if (requestBody.isBinary()) {
-            return Optional.empty();
+            return emptySet();
         }
 
         Map<String, ?> request = JsonUtils.deserializeAsMap(requestBody.asString());
         String query = (String) request.get("query");
+        String operationName = (String) request.get("operationName");
 
         ExecutionInput executionInput = ExecutionInput.newExecutionInput(query).build();
         ParseAndValidateResult parsingResult = ParseAndValidate.parse(executionInput);
         if (parsingResult.isFailure()) {
-            return Optional.empty();
+            return emptySet();
         }
 
-        List<OperationDefinition> operations = parsingResult.getDocument().getDefinitionsOfType(OperationDefinition.class);
-        Optional<OperationDefinition> operation = operations.stream().findFirst();
+        if (operationName != null) {
+            List<OperationDefinition> operations = parsingResult.getDocument().getDefinitionsOfType(OperationDefinition.class);
+            List<OperationDefinition> matchingOperations = operations.stream().filter(operationDefinition -> operationName.equals(operationDefinition.getName())).collect(Collectors.toList());
+            if (matchingOperations.size() != 1) {
+                // Either no matching operation or more than one, either way it's not valid GraphQL
+                return emptySet();
+            }
 
-        return operation
-                .map(op -> new GraphQLOperation(op.getName(), convertType(op.getOperation())))
-                .filter(schemaDeclaredOperations::contains);
+            Optional<OperationDefinition> matchingOperation = matchingOperations.stream().findFirst();
+            return matchingOperation.map(GraphQLSchema::extractOperations).orElseGet(Collections::emptySet);
+        } else {
+            List<OperationDefinition> operations = parsingResult.getDocument().getDefinitionsOfType(OperationDefinition.class);
+            if (operations.size() > 1) {
+                // This is not valid in GraphQL, if you have more than one operation, you need to specify a name
+                return emptySet();
+            }
+            Optional<OperationDefinition> operation = operations.stream().findFirst();
+            return operation.map(GraphQLSchema::extractOperations).orElseGet(Collections::emptySet);
+        }
+    }
+
+    private static Set<GraphQLOperation> extractOperations(OperationDefinition operationDefinition) {
+        List<Field> fields = operationDefinition.getSelectionSet().getSelectionsOfType(Field.class);
+        GraphQLOperationType type = convertType(operationDefinition.getOperation());
+        return fields.stream()
+                .map(field -> new GraphQLOperation(field.getName(), type))
+                .collect(Collectors.toSet());
     }
 
     private static GraphQLOperationType convertType(OperationDefinition.Operation op) {

--- a/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProviderTest.groovy
+++ b/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProviderTest.groovy
@@ -25,7 +25,7 @@ import static org.testingisdocumenting.webtau.graphql.TestUtils.validationResult
 class GraphQLReportDataProviderTest {
     def schemaUrl = ResourceUtils.resourceUrl('test-schema.graphql')
     def coverage = new GraphQLCoverage(new GraphQLSchema(schemaUrl.file))
-    def reportDataProvider = new GraphQLReportDataProvider(coverage)
+    def reportDataProvider = new GraphQLReportDataProvider({ coverage })
 
     @Before
     void injectDummyData() {

--- a/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLSchemaTest.groovy
+++ b/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLSchemaTest.groovy
@@ -1,0 +1,175 @@
+package org.testingisdocumenting.webtau.graphql
+
+import org.junit.Before
+import org.junit.Test
+import org.testingisdocumenting.webtau.http.json.JsonRequestBody
+import org.testingisdocumenting.webtau.utils.ResourceUtils
+
+class GraphQLSchemaTest {
+    private GraphQLSchema schema
+
+    @Before
+    void setUp() {
+        def schemaUrl = ResourceUtils.resourceUrl('test-schema.graphql')
+        schema = new GraphQLSchema(schemaUrl.file)
+    }
+
+    @Test
+    void "short hand syntax for queries"() {
+        def query = '''
+{
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+'''
+        def payload = [
+            query: query
+        ]
+        Set<GraphQLOperation> operations = schema.findOperations(new JsonRequestBody(payload))
+        operations.should == [
+            new GraphQLOperation("allTasks", GraphQLOperationType.QUERY)
+        ]
+    }
+
+    @Test
+    void "explicit type query"() {
+        def query = '''
+query {
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+'''
+        def payload = [
+            query: query
+        ]
+        Set<GraphQLOperation> operations = schema.findOperations(new JsonRequestBody(payload))
+        operations.should == [
+            new GraphQLOperation("allTasks", GraphQLOperationType.QUERY)
+        ]
+    }
+
+    @Test
+    void "named operation"() {
+        def query = '''
+query foobar {
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+'''
+        def payload = [
+            query: query
+        ]
+        Set<GraphQLOperation> operations = schema.findOperations(new JsonRequestBody(payload))
+        operations.should == [
+            new GraphQLOperation("allTasks", GraphQLOperationType.QUERY)
+        ]
+    }
+
+    @Test
+    void "multiple queries"() {
+        def query = '''
+{
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+    taskById(id: "abc") {
+        id
+        description
+    }
+    
+}
+'''
+        def payload = [
+            query: query
+        ]
+        Set<GraphQLOperation> operations = schema.findOperations(new JsonRequestBody(payload))
+        operations.should == [
+            new GraphQLOperation("allTasks", GraphQLOperationType.QUERY),
+            new GraphQLOperation("taskById", GraphQLOperationType.QUERY)
+        ] as Set
+    }
+
+    @Test
+    void "multiple operations without name"() {
+        def query = '''
+query foobar {
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+query hello {
+    taskById(id: "abc") {
+        id
+        description
+    }
+    
+}
+'''
+        def payload = [
+            query: query
+        ]
+        Set<GraphQLOperation> operations = schema.findOperations(new JsonRequestBody(payload))
+        // Multiple named operations without specifying an operation name in request are not valid
+        operations.should == []
+    }
+
+    @Test
+    void "multiple operations with no matching name"() {
+        def query = '''
+query foobar {
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+query hello {
+    taskById(id: "abc") {
+        id
+        description
+    }
+    
+}
+'''
+        def payload = [
+            query: query,
+            operationName: 'does not exist'
+        ]
+        Set<GraphQLOperation> operations = schema.findOperations(new JsonRequestBody(payload))
+        operations.should == []
+    }
+
+    @Test
+    void "multiple operations"() {
+        def query = '''
+query foobar {
+    allTasks(uncompletedOnly: false) {
+        id
+        description
+    }
+}
+query hello {
+    taskById(id: "abc") {
+        id
+        description
+    }
+    
+}
+'''
+        def payload = [
+            query: query,
+            operationName: 'foobar'
+        ]
+        Set<GraphQLOperation> operations = schema.findOperations(new JsonRequestBody(payload))
+        operations.should == [
+            new GraphQLOperation("allTasks", GraphQLOperationType.QUERY)
+        ]
+    }
+}

--- a/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/TestUtils.groovy
+++ b/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/TestUtils.groovy
@@ -36,8 +36,10 @@ class TestUtils {
         def type = operationType.name().toLowerCase()
         def payload = [
             query: """
-                    $type $operationName {
-                      id
+                    $type {
+                        $operationName {
+                            id
+                        }
                     }
                     """.toString()
         ]


### PR DESCRIPTION
This changes two things:
1. fixes local build issues where `mvn package/install` would fail.  This was failing because `GraphQLReportDataProvider` grabbed a reference to `GraphQLCoverage` from `GraphQL` when the data provider was first constructed.  However, during tests, `GraphQL.reset()` ends up being invoked a number of times but nothing recreates the data provider.  Therefore we were recording the correct coverage, just not on the coverage object that the report data provider was using.
1. I had misunderstood slightly the internal representation of queries within the library we use for parsing.  I've addressed this and added some appropriate tests.  Unfortunately, we have overloaded the word "operation' and webtau's meaning of it (the name/type tuple, e.g. `query foo`) differs from GraphQL's meaning (which is essentially a collection of queries, mutations or subscriptions but not mixed).  Our choice of operation here was for symmetry with OpenApi but if someone has a better suggestion for naming to remove the confusion then I'm all ears.