### PR TITLE
Graphql schema loading with headers

### DIFF
--- a/webtau-feature-testing/test-expectations/scenarios/graphql/query/run-details.json
+++ b/webtau-feature-testing/test-expectations/scenarios/graphql/query/run-details.json
@@ -3,7 +3,7 @@
     "scenario" : "list all tasks",
     "shortContainerId" : "query.groovy",
     "stepsSummary" : {
-      "numberOfSuccessful" : 7
+      "numberOfSuccessful" : 9
     }
   } ],
   "exitCode" : 0

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchemaLoader.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchemaLoader.java
@@ -24,6 +24,7 @@ import org.testingisdocumenting.webtau.http.HttpHeader;
 import org.testingisdocumenting.webtau.http.HttpResponse;
 import org.testingisdocumenting.webtau.http.config.HttpConfigurations;
 import org.testingisdocumenting.webtau.http.request.HttpRequestBody;
+import org.testingisdocumenting.webtau.http.validation.HttpValidationHandlers;
 import org.testingisdocumenting.webtau.utils.JsonUtils;
 
 import java.util.HashSet;
@@ -37,7 +38,16 @@ import static org.testingisdocumenting.webtau.http.Http.http;
 public class GraphQLSchemaLoader {
     public static Set<GraphQLQuery> fetchSchemaDeclaredQueries() {
         HttpRequestBody requestBody = GraphQLRequest.body(INTROSPECTION_QUERY, null, null);
-        HttpResponse httpResponse = http.postToFullUrl(HttpConfigurations.fullUrlWithoutEnabledCheck("/graphql"), HttpHeader.EMPTY, requestBody);
+
+        HttpResponse httpResponse = HttpConfigurations.withEnabledConfigurations(() ->
+                HttpValidationHandlers.withDisabledHandlers(() -> {
+                    String fullUrl = HttpConfigurations.fullUrl("/graphql");
+                    return http.postToFullUrl(
+                            fullUrl,
+                            HttpConfigurations.fullHeader(fullUrl, "/graphql", HttpHeader.EMPTY),
+                            requestBody
+                    );
+                }));
         if (httpResponse.getStatusCode() != 200) {
             throw new AssertionError("Error introspecting GraphQL, status code was " + httpResponse.getStatusCode());
         }

--- a/webtau-http/src/main/java/org/testingisdocumenting/webtau/http/config/HttpConfigurations.java
+++ b/webtau-http/src/main/java/org/testingisdocumenting/webtau/http/config/HttpConfigurations.java
@@ -39,34 +39,18 @@ public class HttpConfigurations {
     }
 
     public static <E> E withDisabledConfigurations(Supplier<E> code) {
-        try {
-            disable();
-            return code.get();
-        } finally {
-            enable();
-        }
+        return withEnabledFlagSet(false, code);
     }
 
-    /*
-    There are situations where webtau disables http configuration processing (e.g. while invoking http header providers).
-    This function will return the full url, based on the potentially partial url passed in, if and only if http
-    configuration processing has not been disabled.  This function should be used unless you're absolutely certain
-    that bypassing enabled checks is safe.
-     */
+    public static <E> E withEnabledConfigurations(Supplier<E> code) {
+        return withEnabledFlagSet(true, code);
+    }
+
     public static String fullUrl(String url) {
         if (!enabled.get()) {
             return url;
         }
 
-        return fullUrlWithoutEnabledCheck(url);
-    }
-
-    /*
-    This function will create a full url from a potentially partial url regardless of whether http configuration
-    processing is enabled.  It should be used only in situations which cannot result in any adverse side effects
-    such as infinite loops.
-     */
-    public static String fullUrlWithoutEnabledCheck(String url) {
         String finalUrl = url;
         for (HttpConfiguration configuration : configurations) {
             finalUrl = configuration.fullUrl(finalUrl);
@@ -88,11 +72,13 @@ public class HttpConfigurations {
         return finalHeaders;
     }
 
-    private static void disable() {
-        enabled.set(false);
-    }
-
-    private static void enable() {
-        enabled.set(true);
+    private static <E> E withEnabledFlagSet(boolean enableFlag, Supplier<E> code) {
+        boolean originalFlag = enabled.get();
+        try {
+            enabled.set(enableFlag);
+            return code.get();
+        } finally {
+            enabled.set(originalFlag);
+        }
     }
 }

--- a/webtau-http/src/main/java/org/testingisdocumenting/webtau/http/validation/HttpValidationHandlers.java
+++ b/webtau-http/src/main/java/org/testingisdocumenting/webtau/http/validation/HttpValidationHandlers.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 public class HttpValidationHandlers {
     private static final List<HttpValidationHandler> globalHandlers = ServiceLoaderUtils.load(HttpValidationHandler.class);
     private static final ThreadLocal<List<HttpValidationHandler>> localHandlers = ThreadLocal.withInitial(ArrayList::new);
+    private static final ThreadLocal<Boolean> enabled = ThreadLocal.withInitial(() -> true);
 
     public static void add(HttpValidationHandler handler) {
         globalHandlers.add(handler);
@@ -33,6 +34,15 @@ public class HttpValidationHandlers {
 
     public static void remove(HttpValidationHandler handler) {
         globalHandlers.remove(handler);
+    }
+
+    public static <R> R withDisabledHandlers(Supplier<R> code) {
+        try {
+            enabled.set(false);
+            return code.get();
+        } finally {
+            enabled.set(true);
+        }
     }
 
     public static <R> R withAdditionalHandler(HttpValidationHandler handler, Supplier<R> code) {
@@ -45,6 +55,10 @@ public class HttpValidationHandlers {
     }
 
     public static void validate(HttpValidationResult validationResult) {
+        if (!enabled.get()) {
+            return;
+        }
+
         Stream.concat(localHandlers.get().stream(), globalHandlers.stream())
                 .forEach(c -> c.validate(validationResult));
     }


### PR DESCRIPTION
We need headers from the header provider to be sent to the GraphQL introspection call.  Currently this does not happen because the http call to introspect specifies `Header.EMPTY`.  Doing something similar to `HttpConfigurations. fullUrlWithoutEnabledCheck()` will not work as it results in an infinite loop.  This is the best I've found so far.