### PR TITLE
build: leave clean working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ webtau-report-*.html
 .webtau.cache.json
 .vertx
 todo.md
+doc-artifacts

--- a/webtau-browser/src/test/groovy/org/testingisdocumenting/webtau/browser/documentation/BrowserDocumentationTest.groovy
+++ b/webtau-browser/src/test/groovy/org/testingisdocumenting/webtau/browser/documentation/BrowserDocumentationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.testingisdocumenting.webtau.browser.documentation
 
-
+import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
 import org.testingisdocumenting.webtau.browser.BrowserConfig
@@ -26,11 +26,18 @@ import java.nio.file.Paths
 import static org.testingisdocumenting.webtau.Matchers.code
 import static org.testingisdocumenting.webtau.Matchers.throwException
 import static org.testingisdocumenting.webtau.browser.Browser.browser
+import static org.testingisdocumenting.webtau.cfg.WebTauConfig.getCfg
 
 class BrowserDocumentationTest {
     @BeforeClass
     static void init() {
         BrowserConfig.setHeadless(true)
+        cfg.getDocArtifactsPathConfigValue().set("test", "doc-artifacts")
+    }
+
+    @AfterClass
+    static void cleanUp() {
+        cfg.getDocArtifactsPathConfigValue().reset()
     }
 
     @Test

--- a/webtau-config/src/main/java/org/testingisdocumenting/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/org/testingisdocumenting/webtau/cfg/WebTauConfig.java
@@ -218,6 +218,10 @@ public class WebTauConfig {
         return removeWebtauFromUserAgent;
     }
 
+    public ConfigValue getDocArtifactsPathConfigValue() {
+        return docPath;
+    }
+    
     public Path getDocArtifactsPath() {
         return getWorkingDir().resolve(docPath.getAsPath());
     }


### PR DESCRIPTION
It's nice not to see a load of stuff in `git status` when you've not changed anything but have ran tests.  I've therefore added `doc-artifacts` to gitignore and also made one test generate its artifacts into that dir.

Ideally all these transient things that get generated by the build would go into `target` (and equivalent for npm) so that a clean removes them but that's a bit more work, this first step is easy and does a large part of the job.