### PR TITLE
maven plugin: sort test files

### DIFF
--- a/webtau-maven-plugin/src/main/groovy/org/testingisdocumenting/webtau/maven/WebTauMaven.groovy
+++ b/webtau-maven-plugin/src/main/groovy/org/testingisdocumenting/webtau/maven/WebTauMaven.groovy
@@ -32,8 +32,8 @@ class WebTauMaven {
     static void runTests(Log log, FileSet tests, Map options) {
         def fileSetManager = new FileSetManager()
         def files = tests != null ?
-                fileSetManager.getIncludedFiles(tests) as List:
-                []
+            (fileSetManager.getIncludedFiles(tests) as List).sort() :
+            []
 
         log.info("test files:\n    " + files.join("\n    "))
 


### PR DESCRIPTION
The order doesn't seem totally deterministic, at least not across OSes, so I suggest we sort alphabetically.