### PR TITLE
remove graphQLEnabled flag

### DIFF
--- a/webtau-docs/znai/GraphQL/getting-started.md
+++ b/webtau-docs/znai/GraphQL/getting-started.md
@@ -22,8 +22,9 @@ To run test
 
 Url parameter can be moved to a `webtau.cfg.groovy` file.  Please note that WebTau will automatically append `/graphql` to the url.
 
-You may also wish to add a `graphQLEnabled = true` property which will result in WebTau recording coverage and timing information
-per query for your tests.
+Webtau will attempt to send an introspection query in order to obtain information about the GraphQL schema.  If this fails, it
+will not be able to record coverage information for GraphQL.  Should you wish to fail the test if introspection fails, please
+set the `graphQLIgnoreIntrospectionFailures` property to `false`.
 
 :include-file: examples/graphql/webtau.cfg.groovy {title: "webtau.cfg.groovy"}
 

--- a/webtau-feature-testing/examples/scenarios/graphql/webtau-authed-graphql.cfg.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/webtau-authed-graphql.cfg.groovy
@@ -2,6 +2,6 @@ import scenarios.graphql.HeaderProvider
 
 url = "http://localhost:8180"
 
-graphQLEnabled = true
+graphQLIgnoreIntrospectionFailures = false
 
 httpHeaderProvider = HeaderProvider.&provide

--- a/webtau-feature-testing/examples/scenarios/graphql/webtau-report.cfg.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/webtau-report.cfg.groovy
@@ -2,6 +2,6 @@ package scenarios.graphql
 
 url = "http://localhost:8180"
 
-graphQLEnabled = true
+graphQLIgnoreIntrospectionFailures = false
 
 reportGenerator = Report.&generateReport

--- a/webtau-feature-testing/examples/scenarios/graphql/webtau-weather.cfg.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/webtau-weather.cfg.groovy
@@ -2,4 +2,4 @@ package scenarios.graphql
 
 url = "http://localhost:8180"
 
-graphQLEnabled = true
+graphQLIgnoreIntrospectionFailures = false

--- a/webtau-feature-testing/examples/scenarios/graphql/webtau.cfg.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/webtau.cfg.groovy
@@ -2,6 +2,6 @@ package scenarios.graphql
 
 url = "http://localhost:8180"
 
-graphQLEnabled = true
+graphQLIgnoreIntrospectionFailures = false
 
 reportGenerator = TestReport.&generateReport

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQL.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQL.java
@@ -47,7 +47,7 @@ public class GraphQL {
     }
 
     static void reset() {
-        schema = new GraphQLSchema(GraphQLConfig.isEnabled());
+        schema = new GraphQLSchema();
         coverage = new GraphQLCoverage(schema);
     }
 

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLConfig.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLConfig.java
@@ -25,11 +25,13 @@ import java.util.stream.Stream;
 import static org.testingisdocumenting.webtau.cfg.ConfigValue.declare;
 
 public class GraphQLConfig implements WebTauConfigHandler {
-    static final ConfigValue graphQLEnabled = declare("graphQLEnabled",
-            "enable graphQL coverage and timing capture", () -> false);
+    static final ConfigValue ignoreIntrospectionFailures = declare(
+            "graphQLIgnoreIntrospectionFailures",
+            "ignore graphQL introspection failures, introspection is required for coverage reporting",
+            () -> true);
 
-    static boolean isEnabled() {
-        return graphQLEnabled.getAsBoolean();
+    public static boolean ignoreIntrospectionFailures() {
+        return ignoreIntrospectionFailures.getAsBoolean();
     }
 
     @Override
@@ -39,6 +41,6 @@ public class GraphQLConfig implements WebTauConfigHandler {
 
     @Override
     public Stream<ConfigValue> additionalConfigValues() {
-        return Stream.of(graphQLEnabled);
+        return Stream.of(ignoreIntrospectionFailures);
     }
 }

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchema.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchema.java
@@ -39,18 +39,10 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptySet;
 
 public class GraphQLSchema {
-    private static final Supplier<Optional<Set<GraphQLQuery>>> NO_QUERIES_SUPPLIER = Optional::empty;
-
     private final Supplier<Optional<Set<GraphQLQuery>>> schemaDeclaredQueriesSupplier;
 
-    public GraphQLSchema(boolean isEnabled) {
-        if (!isEnabled) {
-            this.schemaDeclaredQueriesSupplier = NO_QUERIES_SUPPLIER;
-            return;
-        }
-
-        this.schemaDeclaredQueriesSupplier = Suppliers.memoize(() ->
-                Optional.of(GraphQLSchemaLoader.fetchSchemaDeclaredQueries()));
+    public GraphQLSchema() {
+        this.schemaDeclaredQueriesSupplier = Suppliers.memoize(GraphQLSchemaLoader::fetchSchemaDeclaredQueries);
     }
 
     public GraphQLSchema(Set<GraphQLQuery> schemaDeclaredQueries) {

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchemaLoader.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLSchemaLoader.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -41,28 +42,42 @@ import static org.testingisdocumenting.webtau.graphql.GraphQL.GRAPHQL_URL;
 import static org.testingisdocumenting.webtau.http.Http.http;
 
 public class GraphQLSchemaLoader {
-    public static Set<GraphQLQuery> fetchSchemaDeclaredQueries() {
+    public static Optional<Set<GraphQLQuery>> fetchSchemaDeclaredQueries() {
+        HttpResponse httpResponse;
+        try {
+            httpResponse = sendIntrospectionQuery();
+        } catch (Exception e) {
+            return handleIntrospectionError("Error posting GraphQL introspection query", e);
+        }
+        if (httpResponse.getStatusCode() != 200) {
+            return handleIntrospectionError("Error introspecting GraphQL, status code was " + httpResponse.getStatusCode());
+        }
+
+        return convertIntrospectionResponse(httpResponse);
+    }
+
+    private static HttpResponse sendIntrospectionQuery() {
         HttpRequestBody requestBody = GraphQLRequest.body(IntrospectionQuery.INTROSPECTION_QUERY, null, null);
         String fullUrl = HttpConfigurations.fullUrl(GRAPHQL_URL);
         HttpHeader header = HttpConfigurations.fullHeader(fullUrl, GRAPHQL_URL, HttpHeader.EMPTY);
-        HttpResponse httpResponse = http.postToFullUrl(fullUrl, header, requestBody);
-        if (httpResponse.getStatusCode() != 200) {
-            throw new AssertionError("Error introspecting GraphQL, status code was " + httpResponse.getStatusCode());
-        }
 
+        return http.postToFullUrl(fullUrl, header, requestBody);
+    }
+
+    private static Optional<Set<GraphQLQuery>> convertIntrospectionResponse(HttpResponse httpResponse) {
         IntrospectionResultToSchema resultToSchema = new IntrospectionResultToSchema();
         Map<String, ?> response = JsonUtils.deserializeAsMap(httpResponse.getTextContent());
         if (response.containsKey("errors")) {
-            throw new AssertionError("Error introspecting GraphQL, errors found: " + response.get("errors"));
+            return handleIntrospectionError("Error introspecting GraphQL, errors found: " + response.get("errors"));
         }
 
         if (!response.containsKey("data")) {
-            throw new AssertionError("Error introspecting GraphQL, expecting a 'data' field but it was not present");
+            return handleIntrospectionError("Error introspecting GraphQL, expecting a 'data' field but it was not present");
         }
 
         Object data = response.get("data");
         if (!(data instanceof Map)) {
-            throw new AssertionError("Error introspecting GraphQL, expected 'data' to contain a JSON object" +
+            return handleIntrospectionError("Error introspecting GraphQL, expected 'data' to contain a JSON object" +
                     " but it contains a '" + data.getClass().getSimpleName() + "'");
         }
 
@@ -74,7 +89,23 @@ public class GraphQLSchemaLoader {
                 .flatMap(type -> extractTypes(typeDefRegistry, type))
                 .forEach(queries::add);
 
-        return queries;
+        return Optional.of(queries);
+    }
+
+    private static Optional<Set<GraphQLQuery>> handleIntrospectionError(String msg) {
+        return handleIntrospectionError(msg, null);
+    }
+
+    private static Optional<Set<GraphQLQuery>> handleIntrospectionError(String msg, Throwable cause) {
+        if (GraphQLConfig.ignoreIntrospectionFailures()) {
+            return Optional.empty();
+        }
+
+        if (cause == null) {
+            throw new AssertionError(msg);
+        } else {
+            throw new AssertionError(msg, cause);
+        }
     }
 
     private static Stream<GraphQLQuery> extractTypes(TypeDefinitionRegistry registry, GraphQLQueryType type) {

--- a/webtau-groovy/src/main/resources/examples/graphql/webtau.cfg.groovy
+++ b/webtau-groovy/src/main/resources/examples/graphql/webtau.cfg.groovy
@@ -1,2 +1,2 @@
 url = "http://localhost:8080/"
-graphQLEnabled = true
+graphQLIgnoreIntrospectionFailures = false

--- a/webtau-junit4-examples/src/test/resources/webtau-graphql.properties
+++ b/webtau-junit4-examples/src/test/resources/webtau-graphql.properties
@@ -1,2 +1,2 @@
 url = http://localhost
-graphQLEnabled = true
+graphQLIgnoreIntrospectionFailures = false


### PR DESCRIPTION
I removed the `graphQLEnabled` flag but I have replaced it with `graphQLIgnoreIntrospectionFailures` so that people who want to be aware of such failures can be.

Fixes #702 