### PR TITLE
webtau-726 compute success and error branch coverage

### DIFF
--- a/webtau-feature-testing/examples/scenarios/graphql/Report.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/Report.groovy
@@ -21,6 +21,10 @@ class Report {
         reportData.graphQLCoveredQueries = additionalData.graphQLCoveredQueries // All queries present in the GraphQL schema and tested
         reportData.graphQLCoverageSummary = additionalData.graphQLCoverageSummary // Summary of test coverage compared to the GraphQL schema
         reportData.graphQLQueryTimeStatistics = additionalData.graphQLQueryTimeStatistics // Summary of timing by query
+        reportData.graphQLCoveredSuccessBranches = additionalData.graphQLCoveredSuccessBranches // All queries present in the GraphQL schema that were hit with a success result
+        reportData.graphQLSkippedSuccessBranches = additionalData.graphQLSkippedSuccessBranches // All queries present in the GraphQL schema but not hit with a success result
+        reportData.graphQLCoveredErrorBranches = additionalData.graphQLCoveredErrorBranches // All queries present in the GraphQL schema that were hit with an error result
+        reportData.graphQLSkippedErrorBranches = additionalData.graphQLSkippedErrorBranches // All queries present in the GraphQL schema but not hit with an error result
 
         def reportPath = cfg.workingDir.resolve('webtau.graphql-report.json')
         ConsoleOutputs.out('generating report: ', Color.PURPLE, reportPath)

--- a/webtau-feature-testing/examples/scenarios/graphql/TestReport.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/TestReport.groovy
@@ -28,6 +28,10 @@ class TestReport {
 
         validateSkippedQueries(additionalData.graphQLSkippedQueries as Set)
         validateCoveredQueries(additionalData.graphQLCoveredQueries as Set)
+        validateCoveredSuccessBranches(additionalData.graphQLCoveredSuccessBranches as Set)
+        validateSkippedSuccessBranches(additionalData.graphQLSkippedSuccessBranches as Set)
+        validateCoveredErrorBranches(additionalData.graphQLCoveredErrorBranches as Set)
+        validateSkippedErrorBranches(additionalData.graphQLSkippedErrorBranches as Set)
         validateQueryStatistics(additionalData.graphQLQueryTimeStatistics)
         validateCoverageSummary(additionalData.graphQLCoverageSummary)
     }
@@ -57,6 +61,66 @@ class TestReport {
             ],
             [
                 name: 'taskById',
+                type: 'query'
+            ]
+        ] as Set
+    }
+
+    static void validateCoveredSuccessBranches(Set coveredQueries) {
+        coveredQueries.should == [
+            [
+                name: 'allTasks',
+                type: 'query'
+            ],
+            [
+                name: 'complete',
+                type: 'mutation'
+            ],
+            [
+                name: 'taskById',
+                type: 'query'
+            ]
+        ] as Set
+    }
+
+    static void validateSkippedSuccessBranches(Set skippedQueries) {
+        skippedQueries.should == [
+            [
+                name: 'weather',
+                type: 'query'
+            ],
+            [
+                name: 'uncomplete',
+                type: 'mutation'
+            ]
+        ] as Set
+    }
+
+    static void validateCoveredErrorBranches(Set coveredQueries) {
+        coveredQueries.should == [
+                [
+                        name: 'complete',
+                        type: 'mutation'
+                ]
+        ] as Set
+    }
+
+    static void validateSkippedErrorBranches(Set skippedQueries) {
+        skippedQueries.should == [
+            [
+                name: 'allTasks',
+                type: 'query'
+            ],
+            [
+                name: 'uncomplete',
+                type: 'mutation'
+            ],
+            [
+                name: 'taskById',
+                type: 'query'
+            ],
+            [
+                name: 'weather',
                 type: 'query'
             ]
         ] as Set
@@ -97,7 +161,10 @@ class TestReport {
             ],
             totalDeclaredQueries: 5,
             totalCoveredQueries: 3,
-            coverage: 0.6
+            coverage: 0.6,
+            successBranchCoverage: 0.6,
+            errorBranchCoverage: 0.2,
+            branchCoverage: 0.4,
         ]
     }
 }

--- a/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
+++ b/webtau-feature-testing/examples/scenarios/graphql/queryAndMutation.groovy
@@ -48,3 +48,15 @@ scenario("complete a task") {
         taskById.completed.should == true
     }
 }
+
+scenario("cannot complete a completed task") {
+    graphql.execute(completeMutation, [id: "b"]) { // Execute a mutation with a variables map
+        errors.should == null
+        complete.should == true
+    }
+    graphql.execute(completeMutation, [id: "b"]) { // force an error
+        errors[0].message.shouldNot == null
+        complete.should == null
+    }
+}
+

--- a/webtau-feature-testing/pom.xml
+++ b/webtau-feature-testing/pom.xml
@@ -136,6 +136,7 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>com.example.demo.springboot.app.SpringBootDemoApp</mainClass>
+                    <wait>40000</wait>
                 </configuration>
                 <executions>
                     <execution>

--- a/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauGraphQLFeaturesTestData.groovy
+++ b/webtau-feature-testing/src/test/groovy/org/testingisdocumenting/webtau/featuretesting/WebTauGraphQLFeaturesTestData.groovy
@@ -16,6 +16,7 @@
 
 package org.testingisdocumenting.webtau.featuretesting
 
+
 import graphql.schema.GraphQLSchema
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaGenerator
@@ -65,6 +66,8 @@ class WebTauGraphQLFeaturesTestData {
         Task task = taskById(id)
         if (task == null) {
             return false
+        } else if (completed && task.completed) {
+            throw new RuntimeException('you cannot complete a completed task')
         } else {
             task.completed = completed
             return true

--- a/webtau-feature-testing/test-expectations/scenarios/graphql/queryAndMutation/run-details.json
+++ b/webtau-feature-testing/test-expectations/scenarios/graphql/queryAndMutation/run-details.json
@@ -11,6 +11,12 @@
     "stepsSummary" : {
       "numberOfSuccessful" : 9
     }
+  }, {
+    "scenario" : "cannot complete a completed task",
+    "shortContainerId" : "queryAndMutation.groovy",
+    "stepsSummary" : {
+      "numberOfSuccessful" : 8
+    }
   } ],
   "exitCode" : 0
 }

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
@@ -43,8 +43,13 @@ public class GraphQLCoverage {
     }
 
     private boolean isErrorResult(HttpValidationResult validationResult) {
+      try {
         return JsonUtils.convertToTree(JsonUtils.deserialize(validationResult.getResponse().getTextContent()))
             .has("errors");
+      } catch (Exception e) {
+        e.printStackTrace();
+        return false;
+      }
     }
 
     Stream<GraphQLQuery> nonCoveredQueries() {
@@ -58,13 +63,15 @@ public class GraphQLCoverage {
         return coveredQueries.coveredSuccessBranches();
     }
     Stream<GraphQLQuery> nonCoveredSuccessBranches() {
-        return schema.getSchemaDeclaredQueries().filter(o -> coveredQueries.coveredSuccessBranches().noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
+        Stream<GraphQLQuery> coveredSuccessBranches = coveredQueries.coveredSuccessBranches();
+        return schema.getSchemaDeclaredQueries().filter(o -> coveredSuccessBranches.noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
     }
     Stream<GraphQLQuery> coveredErrorBranches() {
         return coveredQueries.coveredErrorBranches();
     }
     Stream<GraphQLQuery> nonCoveredErrorBranches() {
-        return schema.getSchemaDeclaredQueries().filter(o -> coveredQueries.coveredErrorBranches().noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
+        Stream<GraphQLQuery> coveredErrorBranches = coveredQueries.coveredErrorBranches();
+        return schema.getSchemaDeclaredQueries().filter(o -> coveredErrorBranches.noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
     }
 
     Stream<GraphQLQuery> declaredQueries() {

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
@@ -83,6 +83,4 @@ public class GraphQLCoverage {
     Stream<Map.Entry<GraphQLQuery, Set<GraphQLCoveredQueries.Call>>> actualCalls() {
         return coveredQueries.getActualCalls();
     }
-
-
 }

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
@@ -16,8 +16,10 @@
 
 package org.testingisdocumenting.webtau.graphql;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.testingisdocumenting.webtau.http.validation.HttpValidationResult;
 import org.testingisdocumenting.webtau.utils.JsonUtils;
@@ -63,15 +65,15 @@ public class GraphQLCoverage {
         return coveredQueries.coveredSuccessBranches();
     }
     Stream<GraphQLQuery> nonCoveredSuccessBranches() {
-        Stream<GraphQLQuery> coveredSuccessBranches = coveredQueries.coveredSuccessBranches();
-        return schema.getSchemaDeclaredQueries().filter(o -> coveredSuccessBranches.noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
+        List<GraphQLQuery> coveredSuccessBranches = coveredQueries.coveredSuccessBranches().collect(Collectors.toList());
+        return schema.getSchemaDeclaredQueries().filter(o -> coveredSuccessBranches.stream().noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
     }
     Stream<GraphQLQuery> coveredErrorBranches() {
         return coveredQueries.coveredErrorBranches();
     }
     Stream<GraphQLQuery> nonCoveredErrorBranches() {
-        Stream<GraphQLQuery> coveredErrorBranches = coveredQueries.coveredErrorBranches();
-        return schema.getSchemaDeclaredQueries().filter(o -> coveredErrorBranches.noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
+        List<GraphQLQuery> coveredErrorBranches = coveredQueries.coveredErrorBranches().collect(Collectors.toList());;
+        return schema.getSchemaDeclaredQueries().filter(o -> coveredErrorBranches.stream().noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
     }
 
     Stream<GraphQLQuery> declaredQueries() {

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoverage.java
@@ -56,21 +56,25 @@ public class GraphQLCoverage {
 
     Stream<GraphQLQuery> nonCoveredQueries() {
           return schema.getSchemaDeclaredQueries().filter(o -> !coveredQueries.contains(o));
-      }
+    }
 
     Stream<GraphQLQuery> coveredQueries() {
         return coveredQueries.coveredQueries();
     }
+
     Stream<GraphQLQuery> coveredSuccessBranches() {
         return coveredQueries.coveredSuccessBranches();
     }
+
     Stream<GraphQLQuery> nonCoveredSuccessBranches() {
         List<GraphQLQuery> coveredSuccessBranches = coveredQueries.coveredSuccessBranches().collect(Collectors.toList());
         return schema.getSchemaDeclaredQueries().filter(o -> coveredSuccessBranches.stream().noneMatch(graphQLQuery -> graphQLQuery.equals(o)));
     }
+
     Stream<GraphQLQuery> coveredErrorBranches() {
         return coveredQueries.coveredErrorBranches();
     }
+
     Stream<GraphQLQuery> nonCoveredErrorBranches() {
         List<GraphQLQuery> coveredErrorBranches = coveredQueries.coveredErrorBranches().collect(Collectors.toList());;
         return schema.getSchemaDeclaredQueries().filter(o -> coveredErrorBranches.stream().noneMatch(graphQLQuery -> graphQLQuery.equals(o)));

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoveredQueries.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoveredQueries.java
@@ -17,8 +17,10 @@
 package org.testingisdocumenting.webtau.graphql;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class GraphQLCoveredQueries {
@@ -28,10 +30,10 @@ public class GraphQLCoveredQueries {
         actualCallsIdsByQuery = new ConcurrentHashMap<>();
     }
 
-    public void add(GraphQLQuery query, String id, long elapsedTime) {
+    public void add(GraphQLQuery query, String id, long elapsedTime, boolean isError) {
         Set<Call> calls = actualCallsIdsByQuery.computeIfAbsent(query, k -> ConcurrentHashMap.newKeySet());
 
-        calls.add(new Call(id, elapsedTime));
+        calls.add(new Call(id, elapsedTime, isError));
     }
 
     public boolean contains(GraphQLQuery query) {
@@ -46,13 +48,31 @@ public class GraphQLCoveredQueries {
         return actualCallsIdsByQuery.entrySet().stream();
     }
 
+    public Stream<GraphQLQuery> coveredErrorBranches() {
+        return coveredBranches(Call::isErrorResult);
+    }
+
+    public Stream<GraphQLQuery> coveredSuccessBranches() {
+        return coveredBranches(Call::isSuccessResult);
+    }
+
+    private Stream<GraphQLQuery> coveredBranches(Predicate<Call> callPredicate) {
+    return actualCallsIdsByQuery.entrySet().stream()
+        .filter(
+            graphQLQuerySetEntry ->
+                graphQLQuerySetEntry.getValue().stream().anyMatch(callPredicate))
+        .map(Entry::getKey);
+    }
+
     public static class Call {
         private final String id;
         private final long elapsedTime;
+        private final boolean errorResult;
 
-        private Call(String id, long elapsedTime) {
+        private Call(String id, long elapsedTime, boolean isError) {
             this.id = id;
             this.elapsedTime = elapsedTime;
+            this.errorResult = isError;
         }
 
         public String getId() {
@@ -61,6 +81,14 @@ public class GraphQLCoveredQueries {
 
         public long getElapsedTime() {
             return elapsedTime;
+        }
+
+        public boolean isErrorResult() {
+           return errorResult;
+        }
+
+        public boolean isSuccessResult() {
+            return !errorResult;
         }
     }
 }

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoveredQueries.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLCoveredQueries.java
@@ -57,11 +57,11 @@ public class GraphQLCoveredQueries {
     }
 
     private Stream<GraphQLQuery> coveredBranches(Predicate<Call> callPredicate) {
-    return actualCallsIdsByQuery.entrySet().stream()
-        .filter(
-            graphQLQuerySetEntry ->
-                graphQLQuerySetEntry.getValue().stream().anyMatch(callPredicate))
-        .map(Entry::getKey);
+        return actualCallsIdsByQuery.entrySet().stream()
+            .filter(
+                graphQLQuerySetEntry ->
+                    graphQLQuerySetEntry.getValue().stream().anyMatch(callPredicate))
+            .map(Entry::getKey);
     }
 
     public static class Call {

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProvider.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProvider.java
@@ -54,15 +54,15 @@ public class GraphQLReportDataProvider implements ReportDataProvider {
         List<? extends Map<String, ?>> timingByQuery = computeTiming();
         Map<String, ?> coverageSummary = computeCoverageSummary();
 
-    return Stream.of(
-        new ReportCustomData("graphQLSkippedQueries", nonCoveredQueries),
-        new ReportCustomData("graphQLCoveredQueries", coveredQueries),
-        new ReportCustomData("graphQLSkippedSuccessBranches", nonCoveredSuccessBranches),
-        new ReportCustomData("graphQLCoveredSuccessBranches", successBranches),
-        new ReportCustomData("graphQLSkippedErrorBranches", nonCoveredErrorBranches),
-        new ReportCustomData("graphQLCoveredErrorBranches", errorBranches),
-        new ReportCustomData("graphQLQueryTimeStatistics", timingByQuery),
-        new ReportCustomData("graphQLCoverageSummary", coverageSummary));
+        return Stream.of(
+            new ReportCustomData("graphQLSkippedQueries", nonCoveredQueries),
+            new ReportCustomData("graphQLCoveredQueries", coveredQueries),
+            new ReportCustomData("graphQLSkippedSuccessBranches", nonCoveredSuccessBranches),
+            new ReportCustomData("graphQLCoveredSuccessBranches", successBranches),
+            new ReportCustomData("graphQLSkippedErrorBranches", nonCoveredErrorBranches),
+            new ReportCustomData("graphQLCoveredErrorBranches", errorBranches),
+            new ReportCustomData("graphQLQueryTimeStatistics", timingByQuery),
+            new ReportCustomData("graphQLCoverageSummary", coverageSummary));
     }
 
     private List<? extends Map<String, ?>> formatGraphQLQueries(Stream<GraphQLQuery> queryStream) {

--- a/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProvider.java
+++ b/webtau-graphql/src/main/java/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProvider.java
@@ -45,32 +45,13 @@ public class GraphQLReportDataProvider implements ReportDataProvider {
 
     @Override
     public Stream<ReportCustomData> provide(WebTauTestList tests) {
-        List<? extends Map<String, ?>> nonCoveredQueries = coverageSupplier.get().nonCoveredQueries()
-                .map(GraphQLQuery::toMap)
-                .collect(Collectors.toList());
-
-        List<? extends Map<String, ?>> coveredQueries = coverageSupplier.get().coveredQueries()
-                .map(GraphQLQuery::toMap)
-                .collect(Collectors.toList());
-
-        List<? extends Map<String, ?>> successBranches = coverageSupplier.get().coveredSuccessBranches()
-                .map(GraphQLQuery::toMap)
-                .collect(Collectors.toList());
-
-        List<? extends Map<String, ?>> nonCoveredSuccessBranches = coverageSupplier.get().nonCoveredSuccessBranches()
-                .map(GraphQLQuery::toMap)
-                .collect(Collectors.toList());
-
-        List<? extends Map<String, ?>> errorBranches = coverageSupplier.get().coveredErrorBranches()
-                .map(GraphQLQuery::toMap)
-                .collect(Collectors.toList());
-
-        List<? extends Map<String, ?>> nonCoveredErrorBranches = coverageSupplier.get().nonCoveredErrorBranches()
-                .map(GraphQLQuery::toMap)
-                .collect(Collectors.toList());
-
+        List<? extends Map<String, ?>> nonCoveredQueries = formatGraphQLQueries(coverageSupplier.get().nonCoveredQueries());
+        List<? extends Map<String, ?>> coveredQueries = formatGraphQLQueries(coverageSupplier.get().coveredQueries());
+        List<? extends Map<String, ?>> successBranches = formatGraphQLQueries(coverageSupplier.get().coveredSuccessBranches());
+        List<? extends Map<String, ?>> nonCoveredSuccessBranches = formatGraphQLQueries(coverageSupplier.get().nonCoveredSuccessBranches());
+        List<? extends Map<String, ?>> errorBranches = formatGraphQLQueries(coverageSupplier.get().coveredErrorBranches());
+        List<? extends Map<String, ?>> nonCoveredErrorBranches = formatGraphQLQueries(coverageSupplier.get().nonCoveredErrorBranches());
         List<? extends Map<String, ?>> timingByQuery = computeTiming();
-
         Map<String, ?> coverageSummary = computeCoverageSummary();
 
     return Stream.of(
@@ -82,6 +63,10 @@ public class GraphQLReportDataProvider implements ReportDataProvider {
         new ReportCustomData("graphQLCoveredErrorBranches", errorBranches),
         new ReportCustomData("graphQLQueryTimeStatistics", timingByQuery),
         new ReportCustomData("graphQLCoverageSummary", coverageSummary));
+    }
+
+    private List<? extends Map<String, ?>> formatGraphQLQueries(Stream<GraphQLQuery> queryStream) {
+        return queryStream.map(GraphQLQuery::toMap).collect(Collectors.toList());
     }
 
     private List<? extends Map<String, ?>> computeTiming() {

--- a/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLCoverageTest.groovy
+++ b/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLCoverageTest.groovy
@@ -43,8 +43,8 @@ class GraphQLCoverageTest {
 
     @Test
     void "ignores non-graphql queries"() {
-        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '',0, 'GET'))
-        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '',0, 'POST', '/not-graphql'))
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '', 0, 'GET'))
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '', 0, 'POST', '/not-graphql'))
 
         coverage.coveredQueries().should == []
     }

--- a/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLCoverageTest.groovy
+++ b/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLCoverageTest.groovy
@@ -43,9 +43,43 @@ class GraphQLCoverageTest {
 
     @Test
     void "ignores non-graphql queries"() {
-        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, 0, 'GET'))
-        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, 0, 'POST', '/not-graphql'))
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '',0, 'GET'))
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '',0, 'POST', '/not-graphql'))
 
         coverage.coveredQueries().should == []
+    }
+
+    @Test
+    void "should provide queries covering success outcomes and skipped success outcomes"() {
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY))
+        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION))
+
+        coverage.coveredSuccessBranches().should == ['*name'      | '*type'    ] {
+                                                     _______________________________________
+                                                      'allTasks' | GraphQLQueryType.QUERY
+                                                      'complete' | GraphQLQueryType.MUTATION }
+        coverage.coveredErrorBranches().should == []
+        coverage.nonCoveredSuccessBranches().should == ['*name'      | '*type'    ] {
+                                                        _______________________________________
+                                                        'taskById'   | GraphQLQueryType.QUERY
+                                                        'uncomplete' | GraphQLQueryType.MUTATION }
+    }
+
+    @Test
+    void "should provide queries covering error outcomes and skipped error outcomes"() {
+        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION,
+                '{ "dataAndError": {}, "errors": { "message": "error some place" }}'))
+        coverage.recordQuery(validationResult('taskById', GraphQLQueryType.QUERY,
+                '{ "errors": { "message": "error some place" }}'))
+        coverage.coveredErrorBranches().should == ['*name'      | '*type'    ] {
+                                                   _______________________________________
+                                                   'complete'   | GraphQLQueryType.MUTATION
+                                                   'taskById'   | GraphQLQueryType.QUERY }
+
+        coverage.nonCoveredErrorBranches().should == ['*name'     | '*type'    ] {
+                                                      _______________________________________
+                                                     'uncomplete' | GraphQLQueryType.MUTATION
+                                                     'allTasks'   | GraphQLQueryType.QUERY }
+        coverage.coveredSuccessBranches().should == []
     }
 }

--- a/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProviderTest.groovy
+++ b/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/GraphQLReportDataProviderTest.groovy
@@ -28,13 +28,16 @@ class GraphQLReportDataProviderTest {
 
     @Before
     void injectDummyData() {
-        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, 1))
-        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, 2))
-        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, 3))
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '',1))
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '',2))
+        coverage.recordQuery(validationResult('allTasks', GraphQLQueryType.QUERY, '',3))
 
-        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION, 2))
-        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION, 4))
-        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION, 6))
+        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION, '',2))
+        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION, '',4))
+        coverage.recordQuery(validationResult('complete', GraphQLQueryType.MUTATION, '',6))
+
+        coverage.recordQuery(validationResult('taskById', GraphQLQueryType.QUERY,
+                '{ "errors": { "message": "error some place" }}',10))
     }
 
     @Test
@@ -66,6 +69,18 @@ class GraphQLReportDataProviderTest {
                     p95: 6,
                     p99: 6
                 ]
+            ],
+            [
+                name: 'taskById',
+                type: 'query',
+                statistics: [
+                    mean: 10,
+                    min: 10,
+                    max: 10,
+                    count: 1,
+                    p95: 10,
+                    p99: 10
+                ]
             ]
         ] as Set
         timeStats.should == expectedStats
@@ -78,21 +93,24 @@ class GraphQLReportDataProviderTest {
         .getData()
 
         summary.should == [
-            types: [
-                mutation: [
-                    declaredQueries: 2,
-                    coveredQueries: 1,
-                    coverage: 0.5
+                types: [
+                        mutation: [
+                                declaredQueries: 2,
+                                coveredQueries: 1,
+                                coverage: 0.5
+                        ],
+                        query: [
+                                declaredQueries: 2,
+                                coveredQueries: 2,
+                                coverage: 1.0
+                        ]
                 ],
-                query: [
-                    declaredQueries: 2,
-                    coveredQueries: 1,
-                    coverage: 0.5
-                ]
-            ],
-            totalDeclaredQueries: 4,
-            totalCoveredQueries: 2,
-            coverage: 0.5
+                totalDeclaredQueries: 4,
+                totalCoveredQueries: 3,
+                coverage: 0.75,
+                successBranchCoverage: 0.5,
+                errorBranchCoverage: 0.25,
+                branchCoverage: 0.375,
         ]
     }
 }

--- a/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/TestUtils.groovy
+++ b/webtau-graphql/src/test/groovy/org/testingisdocumenting/webtau/graphql/TestUtils.groovy
@@ -16,11 +16,13 @@
 
 package org.testingisdocumenting.webtau.graphql
 
+import org.apache.commons.lang3.StringUtils
 import org.testingisdocumenting.webtau.http.HttpResponse
 import org.testingisdocumenting.webtau.http.json.JsonRequestBody
 import org.testingisdocumenting.webtau.http.request.HttpRequestBody
 import org.testingisdocumenting.webtau.http.validation.HttpValidationResult
 import org.testingisdocumenting.webtau.persona.Persona
+import org.testingisdocumenting.webtau.utils.JsonUtils
 
 class TestUtils {
     static def declaredOperations = [
@@ -30,8 +32,11 @@ class TestUtils {
         new GraphQLQuery("uncomplete", GraphQLQueryType.MUTATION),
     ] as Set
 
-    static HttpValidationResult validationResult(queryName, queryType, elapsedTime = 0, method = 'POST', url = '/graphql') {
-        def response = new HttpResponse()
+    static HttpValidationResult validationResult(queryName, queryType, responseJson = '', elapsedTime = 0, method = 'POST', url = '/graphql') {
+        def json = StringUtils.isNotBlank(responseJson) ? responseJson : JsonUtils.serialize([(queryName): [data: ""]])
+        def response = new HttpResponse(
+                contentType: 'application/json',
+                textContent: json)
         response.statusCode = 200
 
         def result = new HttpValidationResult(Persona.DEFAULT_PERSONA_ID, method, url, url, null, body(queryName, queryType))


### PR DESCRIPTION
Fixes #726 
Inspect the validation result to determine whether it was a success (no errors) or error outcome (errors != null), then use that information to gather and calculate success/error "branch" coverage for all defined graphql operations.