### PR TITLE
cli: fix concurrent modification on output wait

### DIFF
--- a/webtau-cli-groovy/scripts/loop
+++ b/webtau-cli-groovy/scripts/loop
@@ -1,0 +1,4 @@
+#!/bin/bash
+for i in {0..100000}; do
+    echo "line idx $i"
+done

--- a/webtau-cli-groovy/src/test/groovy/org/testingisdocumenting/webtau/cli/CliConcurrencyTest.groovy
+++ b/webtau-cli-groovy/src/test/groovy/org/testingisdocumenting/webtau/cli/CliConcurrencyTest.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 webtau maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.webtau.cli
+
+import org.junit.Test
+
+import static org.testingisdocumenting.webtau.Matchers.contain
+import static org.testingisdocumenting.webtau.cli.Cli.cli
+import static org.testingisdocumenting.webtau.cli.CliTestUtils.supportedPlatformOnly
+
+class CliConcurrencyTest {
+    @Test
+    void "should be able to continuously assert output"() {
+        supportedPlatformOnly {
+            def script = cli.runInBackground('scripts/loop')
+            script.output.waitTo contain('99999')
+        }
+    }
+}

--- a/webtau-cli/src/main/java/org/testingisdocumenting/webtau/cli/CliOutput.java
+++ b/webtau-cli/src/main/java/org/testingisdocumenting/webtau/cli/CliOutput.java
@@ -53,7 +53,7 @@ public class CliOutput implements CliResultExpectations {
     }
 
     public List<String> copyLinesStartingAtIdx(int idx) {
-        return new ArrayList<>(streamGobbler.getLinesStartingAt(idx));
+        return streamGobbler.getLinesStartingAt(idx);
     }
 
     public IOException getException() {

--- a/webtau-cli/src/main/java/org/testingisdocumenting/webtau/cli/StreamGobbler.java
+++ b/webtau-cli/src/main/java/org/testingisdocumenting/webtau/cli/StreamGobbler.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.testingisdocumenting.webtau.cfg.WebTauConfig.getCfg;
@@ -40,7 +39,7 @@ public class StreamGobbler implements Runnable {
 
     public StreamGobbler(InputStream stream) {
         this.stream = stream;
-        this.lines = Collections.synchronizedList(new ArrayList<>());
+        this.lines = new ArrayList<>();
         this.renderOutput = shouldRenderOutput();
     }
 
@@ -52,8 +51,8 @@ public class StreamGobbler implements Runnable {
         return lines.size();
     }
 
-    public List<String> getLinesStartingAt(int idx) {
-        return lines.subList(idx, lines.size());
+    synchronized public List<String> getLinesStartingAt(int idx) {
+        return new ArrayList<>(lines.subList(idx, lines.size()));
     }
 
     public String joinLines() {
@@ -99,8 +98,12 @@ public class StreamGobbler implements Runnable {
                 ConsoleOutputs.out(line);
             }
 
-            lines.add(line);
+            addLine(line);
         }
+    }
+
+    synchronized private void addLine(String line) {
+        lines.add(line);
     }
 
     private boolean shouldRenderOutput() {


### PR DESCRIPTION
@tsiq-karold could you please take a look? I am not sure if there is a better java way to make it concurrency-proof. 