### PR TITLE
add support for synthetic tests

### DIFF
--- a/webtau-core/src/main/java/org/testingisdocumenting/webtau/reporter/WebTauTest.java
+++ b/webtau-core/src/main/java/org/testingisdocumenting/webtau/reporter/WebTauTest.java
@@ -17,17 +17,22 @@
 
 package org.testingisdocumenting.webtau.reporter;
 
+import static org.testingisdocumenting.webtau.reporter.TestStatus.Errored;
+import static org.testingisdocumenting.webtau.reporter.TestStatus.Failed;
+import static org.testingisdocumenting.webtau.reporter.TestStatus.Passed;
+import static org.testingisdocumenting.webtau.reporter.TestStatus.Skipped;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.testingisdocumenting.webtau.reporter.stacktrace.StackTraceCodeEntry;
 import org.testingisdocumenting.webtau.reporter.stacktrace.StackTraceUtils;
 import org.testingisdocumenting.webtau.time.Time;
 import org.testingisdocumenting.webtau.utils.FileUtils;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.testingisdocumenting.webtau.reporter.TestStatus.*;
 
 public class WebTauTest {
     private String id;
@@ -44,6 +49,8 @@ public class WebTauTest {
 
     private boolean isDisabled;
     private String disableReason;
+
+    private boolean isSynthetic;
 
     private boolean isRan;
     private Path workingDir;
@@ -194,6 +201,14 @@ public class WebTauTest {
         return !isSkipped() && !isFailed() && !isErrored();
     }
 
+    public boolean isSynthetic() {
+        return isSynthetic;
+    }
+
+    public void setSynthetic(boolean synthetic) {
+        isSynthetic = synthetic;
+    }
+
     public TestStatus getTestStatus() {
         if (isFailed()) {
             return Failed;
@@ -262,6 +277,8 @@ public class WebTauTest {
         if (shortContainerId != null) {
             result.put("shortContainerId", shortContainerId);
         }
+
+        result.put("synthetic", isSynthetic);
 
         result.put("disabled", isDisabled);
 

--- a/webtau-feature-testing/examples/listeners/MetadataValidationTestListener.groovy
+++ b/webtau-feature-testing/examples/listeners/MetadataValidationTestListener.groovy
@@ -6,7 +6,7 @@ import org.testingisdocumenting.webtau.reporter.WebTauTest
 class MetadataValidationTestListener implements TestListener {
     @Override
     void afterLastTestStatement(WebTauTest test) {
-        if (test.hasSteps() && !test.metadata.has('owner')) {
+        if (!test.isSynthetic() && !test.metadata.has('owner')) {
             throw new RuntimeException('owner for <' + test.scenario + '> is not set')
         }
     }

--- a/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTest.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTest.groovy
@@ -38,12 +38,13 @@ class StandaloneTest implements StepReporter {
     private final Path workingDir
     private final Closure code
 
-    StandaloneTest(Path workingDir, Path filePath, String shortContainerId, String description, Closure code) {
+    StandaloneTest(Path workingDir, Path filePath, String shortContainerId, String description, boolean isSyntheticTest = false, Closure code) {
         this.test = new WebTauTest(workingDir)
         this.test.setId(idGenerator.generate(filePath))
         this.test.setScenario(description)
         this.test.setFilePath(workingDir.relativize(filePath))
         this.test.setShortContainerId(shortContainerId)
+        this.test.setSynthetic(isSyntheticTest)
 
         this.workingDir = workingDir
         this.code = code

--- a/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTest.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTest.groovy
@@ -38,16 +38,20 @@ class StandaloneTest implements StepReporter {
     private final Path workingDir
     private final Closure code
 
-    StandaloneTest(Path workingDir, Path filePath, String shortContainerId, String description, boolean isSyntheticTest = false, Closure code) {
+    StandaloneTest(Path workingDir, Path filePath, String shortContainerId, String description, Closure code) {
         this.test = new WebTauTest(workingDir)
         this.test.setId(idGenerator.generate(filePath))
         this.test.setScenario(description)
         this.test.setFilePath(workingDir.relativize(filePath))
         this.test.setShortContainerId(shortContainerId)
-        this.test.setSynthetic(isSyntheticTest)
 
         this.workingDir = workingDir
         this.code = code
+    }
+
+    StandaloneTest asSynthetic() {
+        test.setSynthetic(true)
+        return this
     }
 
     WebTauTest getTest() {

--- a/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestRunner.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestRunner.groovy
@@ -290,18 +290,16 @@ class StandaloneTestRunner {
 
     private StandaloneTest createBeforeFirstTestListenersAsTest() {
         return new StandaloneTest(workingDir, workingDir.resolve("setup-listeners"),
-                'Setup', 'before first test', true,{ ->
-
+                'Setup', 'before first test', { ->
             TestListeners.beforeFirstTest()
-        })
+        }).asSynthetic()
     }
 
     private StandaloneTest createAfterAllTestListenersAsTest() {
         return new StandaloneTest(workingDir, workingDir.resolve("teardown-listeners"),
-                'Teardown', 'after all tests',true, { ->
-
+                'Teardown', 'after all tests', { ->
             TestListeners.afterAllTests()
-        })
+        }).asSynthetic()
     }
 
     private static void handleTestAndNotifyListeners(StandaloneTest standaloneTest, Closure testHandler) {

--- a/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestRunner.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestRunner.groovy
@@ -290,7 +290,7 @@ class StandaloneTestRunner {
 
     private StandaloneTest createBeforeFirstTestListenersAsTest() {
         return new StandaloneTest(workingDir, workingDir.resolve("setup-listeners"),
-                'Setup', 'before first test', { ->
+                'Setup', 'before first test', true,{ ->
 
             TestListeners.beforeFirstTest()
         })
@@ -298,7 +298,7 @@ class StandaloneTestRunner {
 
     private StandaloneTest createAfterAllTestListenersAsTest() {
         return new StandaloneTest(workingDir, workingDir.resolve("teardown-listeners"),
-                'Teardown', 'after all tests', { ->
+                'Teardown', 'after all tests',true, { ->
 
             TestListeners.afterAllTests()
         })

--- a/webtau-standalone-runner-groovy/src/test/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
@@ -194,6 +194,7 @@ class StandaloneTestRunnerTest {
             def beforeFirstTest = runner.webTauTestList.get(0)
             beforeFirstTest.scenario.should == 'before first test'
             beforeFirstTest.shortContainerId.should == 'Setup'
+            beforeFirstTest.isSynthetic.should == true
         }
     }
 
@@ -231,6 +232,7 @@ class StandaloneTestRunnerTest {
 
             def beforeFirstTest = runner.webTauTestList.get(0)
             beforeFirstTest.scenario.should == 'before first test'
+            beforeFirstTest.isSynthetic.should == true
             beforeFirstTest.shortContainerId.should == 'Setup'
             beforeFirstTest.exception.message.should == 'test error message'
         }
@@ -254,9 +256,10 @@ class StandaloneTestRunnerTest {
 
             runner.webTauTestList.size().should == 4
 
-            def beforeFirstTest = runner.webTauTestList.get(3)
-            beforeFirstTest.scenario.should == 'after all tests'
-            beforeFirstTest.shortContainerId.should == 'Teardown'
+            def afterAllTest = runner.webTauTestList.get(3)
+            afterAllTest.scenario.should == 'after all tests'
+            afterAllTest.shortContainerId.should == 'Teardown'
+            afterAllTest.isSynthetic.should == true
         }
     }
 
@@ -292,10 +295,11 @@ class StandaloneTestRunnerTest {
 
             runner.webTauTestList.size().should == 4
 
-            def beforeFirstTest = runner.webTauTestList.get(3)
-            beforeFirstTest.scenario.should == 'after all tests'
-            beforeFirstTest.shortContainerId.should == 'Teardown'
-            beforeFirstTest.exception.message.should == 'test error message'
+            def afterAllTest = runner.webTauTestList.get(3)
+            afterAllTest.scenario.should == 'after all tests'
+            afterAllTest.isSynthetic.should == true
+            afterAllTest.shortContainerId.should == 'Teardown'
+            afterAllTest.exception.message.should == 'test error message'
         }
     }
 

--- a/webtau-standalone-runner-groovy/src/test/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/org/testingisdocumenting/webtau/runner/standalone/StandaloneTestTest.groovy
@@ -41,6 +41,7 @@ class StandaloneTestTest {
                                              elapsedTime     : 100,
                                              status          : 'Skipped',
                                              disabled        : false,
+                                             synthetic       : false,
                                              metadata        : [:],
                                              screenshot      : 'base64', steps: ['step1', 'step2']])
     }


### PR DESCRIPTION
Fixes https://github.com/testingisdocumenting/webtau/issues/765

Mark auto-generated `WebTauTest` as synthetic; that makes it more elegant to exclude them from metadata checks.